### PR TITLE
Make it possible to change the sensitive and strict options to Route

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -56,18 +56,6 @@
   page.callbacks = [];
 
   /**
-   * enable case-sensitive routes
-   */
-
-  page.sensitive = false;
-
-  /**
-   * enable strict matching for trailing slashes
-   */
-
-  page.strict = false;
-
-  /**
    * Get or set basepath to `path`.
    *
    * @param {String} path


### PR DESCRIPTION
This is a quick way to fix it. 

Now there are several different ways to set options for page.js. Maybe they should be changed so everything was done the same way?

Eg splitting out the options part from `page.start`

``` js
  page({ strict: true }) // calls page.setOptions(obj)

  // add routes

  page() // calls page.start()
```
