### PR TITLE
Infinite redirection loop

### DIFF
--- a/build/page.js
+++ b/build/page.js
@@ -166,7 +166,7 @@
    */
 
   function unhandled(ctx) {
-    if (window.location.pathname == ctx.canonicalPath) return;
+    if (window.location.pathname + window.location.search == ctx.canonicalPath) return;
     page.stop();
     ctx.unhandled = true;
     window.location = ctx.canonicalPath;


### PR DESCRIPTION
Pages that aren't caught by a route will redirect to that page if they aren't already on that page. However, the condition to check whether the current page is already the unhandled route was flawed in that it didn't take into consideration the query string (window.location.search).
