### PR TITLE
fix for bad ie pathname implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,6 +373,7 @@
     if (!el || 'A' != el.nodeName) return;
     var href = el.href;
     var path = el.pathname + el.search;
+    if (path[0] !== '/') path = '/' + path;
     if (el.hash) return;
     if (!sameOrigin(href)) return;
     var orig = path;


### PR DESCRIPTION
Hi,

I tried to figure out for one day now, what was causing problems on IE9. I just discovered that IE handles `el.pathname` quite different, see [this question on stackoverflow](http://stackoverflow.com/questions/956233/javascript-pathname-ie-quirk).

This is a **quick** fix. I did not test this widely across browsers.

Could someone test this on other Internet Explorer versions? I'd like to include it upstream, but this should definitely be verified.
