### PR TITLE
Readded support for ender.

### DIFF
--- a/ender.js
+++ b/ender.js
@@ -1,0 +1,4 @@
+;(function($) {
+	var page = require('page');
+	$.ender({ page: page });
+})(ender);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
       "page": "index.js"
     }
   },
+  "ender": "ender.js",
+  "main": "index.js",
   "devDependencies": {
     "mocha": "*",
     "should": "*",


### PR DESCRIPTION
A commit in the start of August removed the ender-compatibility added by issue #8. This restores it and adds a designated ender hook.
