### PR TITLE
Support IE8+ via HTML5-History-API polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 ;(function(){
 
   /**
@@ -18,6 +17,12 @@
    */
 
   var running;
+
+  /**
+   * To work properly with the URL
+   * history.location generated polyfill in https://github.com/devote/HTML5-History-API
+   */
+  var location = history.location || window.location;
 
   /**
    * Register `path` with callback `fn()`,
@@ -93,7 +98,7 @@
     running = true;
     if (false === options.dispatch) dispatch = false;
     if (false !== options.popstate) addEvent(window, 'popstate', onpopstate);
-    if (false !== options.click) addEvent(document.body, 'click', onclick);
+    if (false !== options.click) addEvent(document, 'click', onclick);
     if (!dispatch) return;
     page.replace(location.pathname + location.search, null, true, dispatch);
   };
@@ -106,8 +111,8 @@
 
   page.stop = function(){
     running = false;
-    removeEvent('click', onclick, false);
-    removeEvent('popstate', onpopstate, false);
+    removeEvent(document, 'click', onclick);
+    removeEvent(window, 'popstate', onpopstate);
   };
 
   /**
@@ -174,7 +179,7 @@
    */
 
   function unhandled(ctx) {
-    if (window.location.pathname + window.location.search == ctx.canonicalPath) return;
+    if (location.pathname + location.search == ctx.canonicalPath) return;
     page.stop();
     ctx.unhandled = true;
     window.location = ctx.canonicalPath;
@@ -411,18 +416,20 @@
    * Basic cross browser event code
    */
 
-   function addEvent( obj, type, fn ) {
-     if ( obj.addEventListener ) {
-       obj.addEventListener( type, fn, false );
-     } else
-       obj.attachEvent( 'on'+type, fn );
+   function addEvent(obj, type, fn) {
+     if (obj.addEventListener) {
+       obj.addEventListener(type, fn, false);
+     } else {
+       obj.attachEvent('on' + type, fn);
+     }
    }
-   
-   function removeEvent( obj, type, fn ) {
-     if ( obj.removeEventListener ) {
-       obj.removeEventListener( type, fn, false );
-     } else
-       obj.detachEvent( 'on'+type, fn );
+
+   function removeEvent(obj, type, fn) {
+     if (obj.removeEventListener) {
+       obj.removeEventListener(type, fn, false);
+     } else {
+       obj.detachEvent('on' + type, fn);
+     }
    }
 
   /**


### PR DESCRIPTION
This patch gets page.js working when polyfilled with @devote's [history polyfill](https://github.com/devote/HTML5-History-API) in IE8 + 9. Solves (more or less) #5.

The tests don't even begin to run in IE, but passes elsewhere, and it passes all my tests on my [Meteor Router](https://github.com/tmeasday/meteor-router). See https://github.com/tmeasday/meteor-router/issues/33 for more information. Haven't had much of a play outside of that context, but my understanding is that it works.
