### PR TITLE
Handle ctrl/cmd/shift clicks on links correctly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,6 +367,7 @@
 
   function onclick(e) {
     if (1 != which(e)) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey) return;
     if (e.defaultPrevented) return;
     var el = e.target;
     while (el && 'A' != el.nodeName) el = el.parentNode;


### PR DESCRIPTION
Such clicks shouldn't try to remain in the app, but instead should fall through to the browser default.
