### PR TITLE
Properly support links with target="_blank"

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,6 +375,7 @@
     var href = el.href;
     var path = el.pathname + el.search;
     if (el.hash || '#' == el.getAttribute('href')) return;
+    if (el.target == "_blank") return;
     if (!sameOrigin(href)) return;
     var orig = path;
     path = path.replace(base, '');


### PR DESCRIPTION
If the href had a target='_blank', then the desired behavior is to open in a new window, and the in-page rendering should be skipped.
