### PR TITLE
Add page.redirect()

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,19 @@
   };
 
   /**
+   * Redirect to page with given `url`.
+   *
+   * @param {String} path
+   * @api public
+   */
+
+  page.redirect = function(url) {
+    setTimeout(function() {
+      page(url);
+    }, 0);
+  };
+
+  /**
    * Dispatch the given `ctx`.
    *
    * @param {Object} ctx


### PR DESCRIPTION
Possible solution for visionmedia/page.js#50.

setTimeout feels hacky but the structure of the page.js API doesn't seem to allow any other way to accomplish this. 

IMHO page.show() page.dispatch() should be merged into page.change(). It would then be obvious what is happening with history because you would be calling either page.replace() or page.change().
