### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "express": "3.0.0beta1",
+    "express": "3.4.4",
     "jade": "0.26.1",
     "serve": "*"
   }


### PR DESCRIPTION
Updated express version in devDependencies. Was using old version of express (connect) which broke the examples.

```
lms@zenb00k|14:08|~/src/page.js (master) $ n examples/
Example server listening on port 4000
GET / 200 43ms
GET /album 302 2ms
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at exports.join (path.js:358:36)
    at exports.send (/home/lms/src/page.js/node_modules/express/node_modules/connect/lib/middleware/static.js:141:20)
    at ServerResponse.res.sendfile (/home/lms/src/page.js/node_modules/express/lib/response.js:243:3)
    at /home/lms/src/page.js/examples/index.js:72:7
    at callbacks (/home/lms/src/page.js/node_modules/express/lib/router/index.js:171:11)
    at param (/home/lms/src/page.js/node_modules/express/lib/router/index.js:145:11)
    at param (/home/lms/src/page.js/node_modules/express/lib/router/index.js:142:11)
    at pass (/home/lms/src/page.js/node_modules/express/lib/router/index.js:152:5)
GET /album/ 500 5ms
```
