### PR TITLE
let page.js handle hash based routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -400,14 +400,9 @@
     // rebuild path
     var path = el.pathname + el.search + (el.hash || '');
 
-    // same page
-    var orig = path + el.hash;
-
-    path = path.replace(base, '');
-    if (base && orig == path) return;
-
     e.preventDefault();
-    page.show(orig);
+ 
+    page.show(path);
   }
 
   /**


### PR DESCRIPTION
When I clicked on `<a href="/legal#privacy">Privacy</a>` page.js did move to `/legal#privacy#privacy`. This is because `path` already contains the hash fragment.

I removed these lines and now it works as it should.
