### PR TITLE
Handle reload on examples.

### DIFF
--- a/examples/album/index.html
+++ b/examples/album/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Profile</title>
     <script src="/page.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/album/style.css" />
   </head>
   <body>
     <h1>Album</h1>
@@ -14,6 +14,6 @@
       <a id="next" href="/">next</a>
     </div>
     <p>View more <a href="https://www.google.com/search?q=grim+fandango">Grim Fandango</a> photos.</p>
-    <script src="app.js"></script>
+    <script src="/album/app.js"></script>
   </body>
 </html>

--- a/examples/chrome/index.html
+++ b/examples/chrome/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Basic</title>
-    <link rel="stylesheet" href="chrome.css" type="text/css">
+    <link rel="stylesheet" href="/chrome/chrome.css" type="text/css">
     <script src="/page.js"></script>
   </head>
   <body>

--- a/examples/profile/index.html
+++ b/examples/profile/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Profile</title>
     <script src="/page.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/profile/style.css" />
   </head>
   <body>
     <h1>Profile</h1>
@@ -17,6 +17,6 @@
     </ul>
 
     <a href="#" id="cycle">Cycle through users</a>
-    <script src="app.js"></script>
+    <script src="/profile/app.js"></script>
   </body>
 </html>

--- a/examples/query-string/index.html
+++ b/examples/query-string/index.html
@@ -2,13 +2,13 @@
 <html>
   <head>
     <title>Query string</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/query-string/style.css" />
   </head>
   <body>
     <h1>Query string</h1>
     <pre>Add a query-string! Maybe: user[name]=tobi</pre>
     <script src="/page.js"></script>
-    <script src="query.js"></script>
-    <script src="app.js"></script>
+    <script src="/query-string/query.js"></script>
+    <script src="/query-string/app.js"></script>
   </body>
 </html>

--- a/examples/server/index.html
+++ b/examples/server/index.html
@@ -3,7 +3,6 @@
   <head>
     <title>Server</title>
     <script src="/page.js"></script>
-    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <h1>Server</h1>
@@ -13,6 +12,6 @@
       <li><a href="./contact">Contact</a></li>
     </ul>
 
-    <script src="app.js"></script>
+    <script src="/server/app.js"></script>
   </body>
 </html>

--- a/examples/state/index.html
+++ b/examples/state/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Profile</title>
     <script src="/page.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/state/style.css" />
   </head>
   <body>
     <h1>Profile</h1>
@@ -16,6 +16,6 @@
       <li><a href="/state/user/sal">Sal</a></li>
     </ul>
 
-    <script src="app.js"></script>
+    <script src="/state/app.js"></script>
   </body>
 </html>

--- a/examples/transitions/index.html
+++ b/examples/transitions/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Page.js - transitions</title>
     <script src="/page.js"></script>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/transitions/style.css" />
   </head>
   <body>
     <section id="content">
@@ -17,6 +17,6 @@
         <a href="/transitions/about">about</a>
       </nav>
     </section>
-    <script src="app.js"></script>
+    <script src="/transitions/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Examples had relative paths for app.js and style.css, which caused them
the examples to break when reloading the browser. Changed the paths to
be absolute (already being done for images), which fixes the issue.
