### PR TITLE
Allow mailto: in href to pass through

### DIFF
--- a/index.js
+++ b/index.js
@@ -391,6 +391,9 @@
     var link = el.getAttribute('href');
     if (el.pathname == location.pathname && (el.hash || '#' == link)) return;
 
+    // Check for mailto: in the href
+    if (link.indexOf("mailto:") > -1) return;
+
     // check target
     if (el.target) return;
 


### PR DESCRIPTION
when clicking on a href that contains a "mailto:" reference allow the href to pass through
