### PR TITLE
Added ability to disable pushstate

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 ;(function(){
 
   /**
@@ -12,7 +11,13 @@
    */
 
   var base = '';
-
+  
+  /**
+   * pushState enabled flag.
+   */
+   
+  var pushstateEnabled = true;
+  
   /**
    * Running flag.
    */
@@ -92,6 +97,7 @@
     if (running) return;
     running = true;
     if (false === options.dispatch) dispatch = false;
+    if (false === options.pushstate) pushstateEnabled = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
     if (false !== options.click) window.addEventListener('click', onclick, false);
     if (!dispatch) return;
@@ -124,7 +130,7 @@
   page.show = function(path, state, dispatch){
     var ctx = new Context(path, state);
     if (false !== dispatch) page.dispatch(ctx);
-    if (!ctx.unhandled) ctx.pushState();
+    if (!ctx.unhandled && pushstateEnabled) ctx.pushState();
     return ctx;
   };
 


### PR DESCRIPTION
Seems rather ridiculous, but I've been presented with a situation where we would simply like to call route handlers and appropriate middleware but don't need pushstate history. So, I elected to add the pushstate parameter to the options to allow disabling of this feature, it's enabled by default. 
