### PR TITLE
Fix ctx.path not defaulting to '/' with empty path and #some-hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,8 +202,8 @@
     this.title = document.title;
     this.state = state || {};
     this.state.path = path;
-    this.querystring = ~i ? path.slice(i + 1) : '';
-    this.pathname = ~i ? path.slice(0, i) : path;
+    this.querystring = ~i ? this.path.slice(i + 1) : '';
+    this.pathname = ~i ? this.path.slice(0, i) : this.path;
     this.params = [];
 
     // fragment
@@ -213,6 +213,7 @@
     this.path = parts[0];
     this.hash = parts[1] || '';
     this.querystring = this.querystring.split('#')[0];
+    this.pathname = this.pathname.split('#')[0];
   }
 
   /**


### PR DESCRIPTION
This PR is submitted without tests, because with the current test set up I can't figure out a way to test this. It could do with the `new Context()` constructor being available…

The value of `ctx.path` is different for `new Context('')` and `new Context('#hash-component')`.

The first `ctx.path = /` and the second `ctx.path = ''`. This is because on line 199 the path defaults to `'/'` while the variable `path` still contains the hash. On line 212 the hash has been stripped and it is possible that it is now an empty string, so should default to `'/'` again.

I hope this makes sense and can get merged. Cheers.
