### PR TITLE
Improvements to bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     ".gitignore",
     ".npmignore",
     ".travis.yml",
+    "component.json",
     "bower.json",
     "examples",
     "History.md",


### PR DESCRIPTION
This pull request renames component.json to bower.json, as component.json will eventually be deprecated by bower.

It also adds an `ignore` section to ignore any files not needed for deployment.

This is based on the assumption that you should `bower install page` if you just want the library code and `npm install page` if you want everything in order to tinker.
