### PR TITLE
pushState before dispatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@
 
   page.show = function(path, state, dispatch){
     var ctx = new Context(path, state);
-    if (false !== dispatch) page.dispatch(ctx);
     if (!ctx.unhandled) ctx.pushState();
+    if (false !== dispatch) page.dispatch(ctx);
     return ctx;
   };
 


### PR DESCRIPTION
Otherwise, window.location.pathname does not give accurate representation of current route upon dispatch
