### PR TITLE
component.json: Fix path-to-regexp version

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,6 +7,6 @@
   "scripts": ["index.js"],
   "license": "MIT",
   "dependencies": {
-    "component/path-to-regexp": "0.2.1"
+    "component/path-to-regexp": "v0.2.1"
   }
 }


### PR DESCRIPTION
for some supercool awesome reason, path-to-regexp prefixes its versions 
with a redundant "v".  component 0.x doesn't support this behaviour.
