### PR TITLE
Update examples port in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ page()
     $ cd page.js
     $ npm install
     $ node examples
-    $ open http://localhost:3000
+    $ open http://localhost:4000
 
  Currently we have examples for:
 


### PR DESCRIPTION
Hi,

I noticed Readme.md says that examples run on port 3000, when they actually run on port 4000. So I updated the file.

Cheers
