### PR TITLE
Allow for missing href in anchors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,7 +366,7 @@
     if (el.pathname == location.pathname && (el.hash || '#' == link)) return;
 
     // Check for mailto: in the href
-    if (link.indexOf("mailto:") > -1) return;
+    if (link && link.indexOf("mailto:") > -1) return;
 
     // check target
     if (el.target) return;
@@ -405,5 +405,5 @@
   function sameOrigin(href) {
     var origin = location.protocol + '//' + location.hostname;
     if (location.port) origin += ':' + location.port;
-    return 0 == href.indexOf(origin);
+    return (href && (0 == href.indexOf(origin)));
   }


### PR DESCRIPTION
This fixes calling 'indexOf' on an undefined value when an anchor has no href.

Reading the spec, it sounds like hrefs are technically optional on anchor tags:

```
When the A element's href attribute is set...
```

http://www.w3.org/TR/html401/struct/links.html
