### PR TITLE
Make sameOrigin a public method

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,3 +407,5 @@
     if (location.port) origin += ':' + location.port;
     return (href && (0 == href.indexOf(origin)));
   }
+
+  page.sameOrigin = sameOrigin;


### PR DESCRIPTION
This small change allows other JS in your app to use the sameOrigin method provided by page.js by calling `page.sameOrigin(href);`.

I've found it useful to use this function in my own code and it'd be handy to just use the one provided by page.js rather than copy/paste it out and load it into memory twice in two different JS libraries.
