### PR TITLE
Prevent undefined error if the <a> does not have an href attribute.

### DIFF
--- a/page.js
+++ b/page.js
@@ -364,6 +364,7 @@
 
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
+    if (link === null) return;
     if (el.pathname == location.pathname && (el.hash || '#' == link)) return;
 
     // Check for mailto: in the href


### PR DESCRIPTION
This can occur if the clicked element is an `a` tag but the `href` attribute has not been set.
