### PR TITLE
Add hashbang option

### DIFF
--- a/page.js
+++ b/page.js
@@ -33,6 +33,12 @@
   var running;
 
   /**
+  * HashBang option
+  */
+
+  var hashbang = false;
+
+  /**
    * Register `path` with callback `fn()`,
    * or route `path`, or `page.start()`.
    *
@@ -107,8 +113,14 @@
     if (false === options.dispatch) dispatch = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
     if (false !== options.click) window.addEventListener('click', onclick, false);
+    if (true === options.hashbang) hashbang = true;
     if (!dispatch) return;
-    var url = location.pathname + location.search + location.hash;
+
+    if (hashbang && location.hash.indexOf('#!') === 0)
+      var url = location.hash.substr(2) + location.search;
+    else
+      var url = location.pathname + location.search + location.hash;
+
     page.replace(url, null, true, dispatch);
   };
 
@@ -240,7 +252,7 @@
    */
 
   Context.prototype.pushState = function(){
-    history.pushState(this.state, this.title, this.canonicalPath);
+    history.pushState(this.state, this.title, (hashbang && this.canonicalPath != '/' ? '#!' + this.canonicalPath : this.canonicalPath));
   };
 
   /**
@@ -250,7 +262,7 @@
    */
 
   Context.prototype.save = function(){
-    history.replaceState(this.state, this.title, this.canonicalPath);
+    history.replaceState(this.state, this.title, (hashbang && this.canonicalPath != '/' ? '#!' + this.canonicalPath : this.canonicalPath));
   };
 
   /**


### PR DESCRIPTION
I didn't expect it when I started my most recent project but it turns out I did need the option to utilize hashbang-type urls. After realizing that there was no officially supported hashbang option I came across this issue: https://github.com/visionmedia/page.js/pull/86. Unfortunately, it looks like there are some merge conflicts that, I'm assuming, are keeping it from getting merged into master. Is that why it's still pending?

It seems to be a common request for the library so I thought I'd try to do my part to help. At the very least I can use it in my project but hopefully the team is willing to merge it into master. It's a very minimal code change and @quangv actually did all of the heavy lifting (big thanks!). I just made a couple minor adjustments and ensured the tests continued to pass.

Unfortunately, I don't believe this is a solution for older browsers. I still believe this will only work for browsers that natively support pushState and that's all I ended up needing it for. 

I'm still relatively new to testing but I was able to run the existing test suite successfully. I wasn't sure as to the most efficient way to handle running the tests with a different option object so I manually set the `hashbang: true` option and re-ran the tests. I assumed rewriting the same exact tests wouldn't be very DRY. If any of you regular mocha users have any suggestions as to the best way to handle that I'd be happy to update the tests accordingly. 

Cheers!
