### PR TITLE
Add </script> to CDN example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ page()
   Via CDN and script tag:
 
   ```html
-  <script src="https://cdn.rawgit.com/visionmedia/page.js/1.4.0/page.js"></script>
+  <script src="https://cdn.rawgit.com/visionmedia/page.js/master/page.js"></script>
   ```
 
 ## Running examples


### PR DESCRIPTION
Just added a `</script>` tag after the inclusion script tag to make the example actually work.
