### PR TITLE
Ignore <a download> links in click handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,6 +387,9 @@
     while (el && 'A' != el.nodeName) el = el.parentNode;
     if (!el || 'A' != el.nodeName) return;
 
+    // Ignore if tag has a "download" attribute
+    if (el.getAttribute("download")) return;
+
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
     if (el.pathname == location.pathname && (el.hash || '#' == link)) return;


### PR DESCRIPTION
The HTML5 "download" attribute tells the browser to download a file to disk when an <a> element is clicked instead of navigate to the href. It should be ignored by page.js since it does not affect history, the same as "mailto:" is ignored.
