### PR TITLE
skip route processing if another one is called

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,12 @@
   page.callbacks = [];
 
   /**
+   * Current path being processed
+   * @type {String}
+   */
+  page.current = '';
+
+  /**
    * Get or set basepath to `path`.
    *
    * @param {String} path
@@ -137,6 +143,7 @@
    */
 
   page.stop = function(){
+    page.current = '';
     if (!running) return;
     running = false;
     window.removeEventListener('click', onclick, false);
@@ -154,6 +161,7 @@
    */
 
   page.show = function(path, state, dispatch){
+    page.current = path;
     var ctx = new Context(path, state);
     if (false !== dispatch) page.dispatch(ctx);
     if (false !== ctx.handled) ctx.pushState();
@@ -185,6 +193,7 @@
    */
 
   page.replace = function(path, state, init, dispatch){
+    page.current = path;
     var ctx = new Context(path, state);
     ctx.init = init;
     ctx.save(); // save before dispatching, which may redirect
@@ -204,6 +213,10 @@
 
     function next() {
       var fn = page.callbacks[i++];
+      if(ctx.path !== page.current){
+        ctx.handled = false;
+        return;
+      }
       if (!fn) return unhandled(ctx);
       fn(ctx, next);
     }


### PR DESCRIPTION
think:

``` js
page('/slow', function(ctx, next) {
    setTimeout(function(){next()}, 10000);
}, renderHtml);

page('/fast', renderHtml);

page('/slow');
page('/fast');
```

without this fix the html on the page would be from the slow route.
