### PR TITLE
Remove URL encoding before parsing paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,6 +247,13 @@
     location.href = ctx.canonicalPath;
   }
 
+  /**
+  * Remove URL encoding from the given `str`.
+  * Accommodates whitespace in both x-www-form-urlencoded
+  * and regular percent-encoded form.
+  *
+  * @param {str} URL component to decode
+  */
   function decodeURLEncodedURIComponent(str) {
     return decodeURIComponent(str.replace(/\+/g, ' '));
   }


### PR DESCRIPTION
URL encoding should be removed before parsing the path in Context's constructor. This saves the user a ton of work when working with Context object properties.
