### PR TITLE
Update `onclick` to better support hashbang paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,11 +269,12 @@
 
   function Context(path, state) {
     path = decodeURLEncodedURIComponent(path);
-    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + path;
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? '#!' : '') + path;
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
+    if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
     this.title = document.title;
     this.state = state || {};
@@ -288,11 +289,13 @@
 
     // fragment
     this.hash = '';
-    if (!~this.path.indexOf('#')) return;
-    var parts = this.path.split('#');
-    this.path = parts[0];
-    this.hash = parts[1] || '';
-    this.querystring = this.querystring.split('#')[0];
+    if (!hashbang) {
+      if (!~this.path.indexOf('#')) return;
+      var parts = this.path.split('#');
+      this.path = parts[0];
+      this.hash = parts[1] || '';
+      this.querystring = this.querystring.split('#')[0];
+    }
   }
 
   /**
@@ -423,6 +426,8 @@
     if (e.state) {
       var path = e.state.path;
       page.replace(path, e.state);
+    } else {
+      page.show(location.pathname + location.hash)
     }
   }
 
@@ -445,7 +450,7 @@
 
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
-    if (el.pathname === location.pathname && (el.hash || '#' === link)) return;
+    if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
     // Check for mailto: in the href
     if (link && link.indexOf("mailto:") > -1) return;
@@ -463,6 +468,7 @@
     var orig = path;
 
     path = path.replace(base, '');
+    if (hashbang) path = path.replace('#!', '');
 
     if (base && orig === path) return;
 

--- a/page.js
+++ b/page.js
@@ -172,10 +172,10 @@
   page.redirect = function(from, to) {
     // Define route from a path to another
     if ('string' === typeof from && 'string' === typeof to) {
-       page(from, function (e) {
+      page(from, function (e) {
         setTimeout(function() {
           page.replace(to);
-        });
+        },0);
       });
     }
 
@@ -183,9 +183,8 @@
     if('string' === typeof from && 'undefined' === typeof to) {
       setTimeout(function() {
           page.replace(from);
-      });
+      },0);
     }
-
   };
 
   /**
@@ -250,6 +249,17 @@
   }
 
   /**
+  * Remove URL encoding from the given `str`.
+  * Accommodates whitespace in both x-www-form-urlencoded
+  * and regular percent-encoded form.
+  *
+  * @param {str} URL component to decode
+  */
+  function decodeURLEncodedURIComponent(str) {
+    return decodeURIComponent(str.replace(/\+/g, ' '));
+  }
+
+  /**
    * Initialize a new "request" `Context`
    * with the given `path` and optional initial `state`.
    *
@@ -259,11 +269,13 @@
    */
 
   function Context(path, state) {
-    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + path;
+    path = decodeURLEncodedURIComponent(path);
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? '#!' : '') + path;
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
+    if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
     this.title = document.title;
     this.state = state || {};
@@ -278,11 +290,13 @@
 
     // fragment
     this.hash = '';
-    if (!~this.path.indexOf('#')) return;
-    var parts = this.path.split('#');
-    this.path = parts[0];
-    this.hash = parts[1] || '';
-    this.querystring = this.querystring.split('#')[0];
+    if (!hashbang) {
+      if (!~this.path.indexOf('#')) return;
+      var parts = this.path.split('#');
+      this.path = parts[0];
+      this.hash = parts[1] || '';
+      this.querystring = this.querystring.split('#')[0];
+    }
   }
 
   /**
@@ -413,6 +427,8 @@
     if (e.state) {
       var path = e.state.path;
       page.replace(path, e.state);
+    } else {
+      page.show(location.pathname + location.hash)
     }
   }
 
@@ -435,7 +451,7 @@
 
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
-    if (el.pathname === location.pathname && (el.hash || '#' === link)) return;
+    if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
     // Check for mailto: in the href
     if (link && link.indexOf("mailto:") > -1) return;
@@ -453,6 +469,7 @@
     var orig = path;
 
     path = path.replace(base, '');
+    if (hashbang) path = path.replace('#!', '');
 
     if (base && orig === path) return;
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -20,6 +20,7 @@ var called = false,
   htmlWrapper,
   html = '',
   base = '',
+  hashbang = false,
   beforeTests = function(options) {
     page.callbacks = [];
     options = options || {};
@@ -102,7 +103,7 @@ var called = false,
     describe('ctx.pathname', function() {
       it('should default to ctx.path', function(done) {
         page('/pathname-default', function(ctx) {
-          expect(ctx.pathname).to.equal(base+ '/pathname-default');
+          expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') + '/pathname-default');
           done();
         });
 
@@ -111,7 +112,7 @@ var called = false,
 
       it('should omit the query string', function(done) {
         page('/pathname', function(ctx) {
-          expect(ctx.pathname).to.equal(base+ '/pathname');
+          expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') + '/pathname');
           done();
         });
 
@@ -225,8 +226,9 @@ describe('Html5 history navigation', function() {
 describe('Hashbang option enabled', function() {
 
   before(function() {
+    hashbang = true
     beforeTests({
-      hashbang: true
+      hashbang: hashbang
     });
   });
 


### PR DESCRIPTION
I had some trouble linking to other pages after enabling the `hashbang` option. Even though a URL like `/demo.html#!/events` would work fine when manually entered, the same URL used in a link just updated the URL but didn't load any route (even if a catchall were specified).

I dug into the code a bit and found that the `onclick` function was stripping everything after `#` and treating it as a hash parameter. That makes sense if `hashbang` is set to false, but otherwise the hashbang should be considered part of the pathname.

I did my best to fix up the behavior without affecting how things work with `hashbang` disabled. Tests are passing with a few tweaks. Feedback is welcome, and I'm happy to discuss alternative approaches. Thanks!
