### PR TITLE
Avoid augmenting passed-in state objects when creating Context instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@
       }
     }
 
-    return prop;
+    return target;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -311,6 +311,25 @@
   }
 
   /**
+   * Create a shallow copy of `source`
+   *
+   * @param {Object} source
+   * @api private
+   */
+
+  function extend(source) {
+    var target = {};
+
+    for(var prop in source) {
+      if(Object.hasOwnProperty.call(source, prop)) {
+        target[prop] = source[prop];
+      }
+    }
+
+    return prop;
+  }
+
+  /**
    * Initialize a new "request" `Context`
    * with the given `path` and optional initial `state`.
    *
@@ -329,7 +348,7 @@
     if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
     this.title = document.title;
-    this.state = state || {};
+    this.state = extend(state) || {};
     this.state.path = path;
     this.querystring = ~i ? path.slice(i + 1) : '';
     this.pathname = ~i ? path.slice(0, i) : path;


### PR DESCRIPTION
The Context constructor currently adds a path property to passed-in state objects. This is dangerous if the user has any further use for the passed-in object. Creating a shallow copy of the state object before assigning it to the Context instance solves this problem.
