### PR TITLE
Add tests for URL decoding

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ page('/default');
   - `popstate` bind to popstate [__true__]
   - `dispatch` perform initial dispatch [__true__]
   - `hashbang` add `#!` before urls [__false__]
-  - `decodeURLComponents` remove URL encoding from path components and route params [__true__]
+  - `decodeURLComponents` remove URL encoding from path components (query string, pathname, hash) [__true__]
 
   If you wish to load serve initial content
   from the server you likely will want to

--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@
   var dispatch = true;
 
   /**
-  * Decode URL components (query string, pathname, hash) and route param matches.
-  * Accommodates both regular percent encoding and x-www-form-urlencoded format.
-  */
+   * Decode URL components (query string, pathname, hash).
+   * Accommodates both regular percent encoding and x-www-form-urlencoded format.
+   */
   var decodeURLComponents = true;
 
   /**
@@ -495,9 +495,9 @@
     // 1. "download" attribute
     // 2. rel="external" attribute
     if (el.getAttribute('download') ||
-        el.getAttribute('rel') === 'external'
-       ) return;
-    
+      el.getAttribute('rel') === 'external'
+    ) return;
+
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
     if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,7 @@
     html = '',
     base = '',
     hashbang = false,
+    decodeURLComponents = true,
     chai = this.chai,
     expect = this.expect,
     page = this.page,
@@ -187,6 +188,15 @@
 
           page('/querystring?hello=there');
         });
+
+        it('should accommodate URL encoding', function(done) {
+          page('/whatever', function(ctx) {
+            expect(ctx.querystring).to.equal(decodeURLComponents ? 'queryParam=string with whitespace' : 'queryParam=string%20with%20whitespace');
+            done();
+          });
+
+          page('/whatever?queryParam=string%20with%20whitespace');
+        });
       });
 
       describe('ctx.pathname', function() {
@@ -206,6 +216,27 @@
           });
 
           page('/pathname?hello=there');
+        });
+
+        it('should accommodate URL encoding', function(done) {
+          page('/long path with whitespace', function(ctx) {
+            expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') +
+              (decodeURLComponents ? '/long path with whitespace' : '/long%20path%20with%20whitespace'));
+            done();
+          });
+
+          page('/long%20path%20with%20whitespace');
+        });
+      });
+
+      describe('ctx.params', function() {
+        it('should always be URL-decoded', function(done) {
+          page('/whatever/:param', function(ctx) {
+            expect(ctx.params.param).to.equal('param with whitespace');
+            done();
+          });
+
+          page('/whatever/param%20with%20whitespace');
         });
       });
 
@@ -311,8 +342,6 @@
           });
         });
 
-
-
       });
     },
     afterTests = function() {
@@ -372,6 +401,21 @@
       afterTests();
     });
 
+  });
+
+  describe('URL path component decoding disabled', function() {
+    before(function() {
+      decodeURLComponents = false;
+      beforeTests({
+        decodeURLComponents: decodeURLComponents
+      });
+    });
+
+    tests();
+
+    after(function() {
+      afterTests();
+    });
   });
 
 }).call(this);


### PR DESCRIPTION
\+ update readme (ctx params are always decoded, regardless of the decodeURLComponents flag).
