### PR TITLE
Make page.js requireable by node without jsdom

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
    * history.location generated polyfill in https://github.com/devote/HTML5-History-API
    */
 
-  var location = window.history.location || window.location;
+  var location = window && window.history.location || window.location;
 
   /**
    * Perform initial dispatch.


### PR DESCRIPTION
Originally reported in #178.

The specific use case this solves for me is where I'm requiring page.js into my jsx files and rendering using it on both the server and client.

While it would be amazing to have this merged as is, I expect there will be some discussion around it.
