### PR TITLE
Safer checking for window object to enable server-side use

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
    * history.location generated polyfill in https://github.com/devote/HTML5-History-API
    */
 
-  var location = window && (window.history.location || window.location);
+  var location = ('undefined' != typeof window) && (window.history.location || window.location);
 
   /**
    * Perform initial dispatch.


### PR DESCRIPTION
This only enables you to require page.js in a clean node environment without crashing. All I did is check for `window` availability safely. Since even Mocha tests are running with jsdom, I'm not entirely sure how to test this.

Partially resolves #191