### PR TITLE
Include page.js in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "should": "*"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "page.js"
   ]
 }


### PR DESCRIPTION
Right now page.js is not included in the npm package, that seems like a mistake.

If you merge this pull request, could you also be so kind to release a new version to npm.