### PR TITLE
Fix for page.js on NW.js on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -554,7 +554,7 @@
     var path = el.pathname + el.search + (el.hash || '');
 
     // strip leading "/C:" on nwjs on windows
-    if (typeof process !== 'undefined' && typeof require !== 'undefined' && typeof require('nw.gui') !== 'undefined' && path.substring(0, 4) === '/C:/') {
+    if (typeof process !== 'undefined' && typeof require !== 'undefined' && path.substring(0, 4) === '/C:/') {
       path = path.replace('/C:/', '/');
     }
     

--- a/index.js
+++ b/index.js
@@ -553,9 +553,9 @@
     // rebuild path
     var path = el.pathname + el.search + (el.hash || '');
 
-    // strip leading "/C:" on nwjs on windows
-    if (typeof process !== 'undefined' && path.substring(0, 4) === '/C:/') {
-      path = path.replace('/C:/', '/');
+    // strip leading "/[drive letter]:" on NW.js on windows
+    if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {
+      path = path.replace(/^\/[a-zA-Z]:\//, '/');
     }
     
     // same page

--- a/index.js
+++ b/index.js
@@ -553,7 +553,7 @@
     // rebuild path
     var path = el.pathname + el.search + (el.hash || '');
 
-    // strip leading "/[drive letter]:" on NW.js on windows
+    // strip leading "/[drive letter]:" on NW.js on Windows
     if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {
       path = path.replace(/^\/[a-zA-Z]:\//, '/');
     }

--- a/index.js
+++ b/index.js
@@ -554,7 +554,7 @@
     var path = el.pathname + el.search + (el.hash || '');
 
     // strip leading "/C:" on nwjs on windows
-    if (typeof process !== 'undefined' && typeof require !== 'undefined' && path.substring(0, 4) === '/C:/') {
+    if (typeof process !== 'undefined' && path.substring(0, 4) === '/C:/') {
       path = path.replace('/C:/', '/');
     }
     

--- a/index.js
+++ b/index.js
@@ -553,6 +553,11 @@
     // rebuild path
     var path = el.pathname + el.search + (el.hash || '');
 
+    // strip leading "/C:" on nwjs on windows
+    if (typeof process !== 'undefined' && typeof require !== 'undefined' && typeof require('nw.gui') !== 'undefined' && path.substring(0, 4) === '/C:/') {
+      path = path.replace('/C:/', '/');
+    }
+    
     // same page
     var orig = path;
 


### PR DESCRIPTION
This check ensures that the leading "/C:" prepended to `el.pathname` in [NW.js](https://github.com/nwjs/nw.js) on Windows is stripped so that `el.pathname` returns the same value on all operating systems.

For instance in a NW.js app on Windows, if you write HTML like this:

```html
<a href='/somewhere'>Somewhere</a>
```

Then `el.pathname` in page.js is `/somewhere` in Linux/Mac, but returns `/C:/somewhere` in Windows.

This PR normalizes the path.