### PR TITLE
Fix for post load event regression

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,11 +155,18 @@
     if (false !== options.popstate) {
       
       // this hack resolves https://github.com/visionmedia/page.js/issues/213
-      window.addEventListener('load', function() {
-        setTimeout(function() {
-          window.addEventListener('popstate', onpopstate, false);
-        }, 0);
-      }, false);
+      if (document.readyState !== 'complete') {
+        // load event has not fired
+        window.addEventListener('load', function() {
+          setTimeout(function() {
+            window.addEventListener('popstate', onpopstate, false);
+          }, 0);
+        }, false);
+      }
+      else {
+        // load event has fired
+        window.addEventListener('popstate', onpopstate, false);
+      }
     }
     if (false !== options.click) {
       window.addEventListener('click', onclick, false);


### PR DESCRIPTION
If page.js is loaded after the `load` event fires, the `onpopstate` function is never attached to the `popstate` event.

This tweak prevents that, but also prevents the hack which fixes #213 from working if page.js is loaded after the load event fires.

I think this is an acceptable compromise for now, because it allows #213 to remain fixed if page.js is loaded before the `load` event fires.

We can always replace this with something better if someone identifies a solution which fixes it in all cases.