### PR TITLE
use document event listener for click event instead of window

### DIFF
--- a/page.js
+++ b/page.js
@@ -162,7 +162,7 @@
     if (false === options.decodeURLComponents) decodeURLComponents = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
     if (false !== options.click) {
-      window.addEventListener(clickEvent, onclick, false);
+      document.addEventListener(clickEvent, onclick, false);
     }
     if (true === options.hashbang) hashbang = true;
     if (!dispatch) return;
@@ -181,7 +181,7 @@
     page.current = '';
     page.len = 0;
     running = false;
-    window.removeEventListener(clickEvent, onclick, false);
+    document.removeEventListener(clickEvent, onclick, false);
     window.removeEventListener('popstate', onpopstate, false);
   };
 


### PR DESCRIPTION
I ran into a bug where the click event registered in page.js did not fire in firefox. I tried to pin it down, and I saw that the `window` object does not have a `click` event documented, but the `document` object has[1].
Changing the code solved my problem.
This PR changes the `eventlistener` for the `click` event from `window` to `document`.

[1]https://developer.mozilla.org/en-US/docs/Web/Events/click