### PR TITLE
Preventing completion of exit route will prevent navigation. Fixes #80

### DIFF
--- a/page.js
+++ b/page.js
@@ -162,7 +162,7 @@
     if (false === options.decodeURLComponents) decodeURLComponents = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
     if (false !== options.click) {
-      window.addEventListener(clickEvent, onclick, false);
+      document.addEventListener(clickEvent, onclick, false);
     }
     if (true === options.hashbang) hashbang = true;
     if (!dispatch) return;
@@ -181,7 +181,7 @@
     page.current = '';
     page.len = 0;
     running = false;
-    window.removeEventListener(clickEvent, onclick, false);
+    document.removeEventListener(clickEvent, onclick, false);
     window.removeEventListener('popstate', onpopstate, false);
   };
 
@@ -198,8 +198,15 @@
   page.show = function(path, state, dispatch, push) {
     var ctx = new Context(path, state);
     page.current = ctx.path;
-    if (false !== dispatch) page.dispatch(ctx);
-    if (false !== ctx.handled && false !== push) ctx.pushState();
+    function dispatchNext() {
+      if (false !== dispatch) page.dispatchEnter(ctx);
+      if (false !== ctx.handled && false !== push) ctx.pushState();
+    }
+    if (false !== dispatch) {
+      page.dispatchExit(ctx, dispatchNext);
+    } else {
+      dispatchNext();
+    }
     return ctx;
   };
 
@@ -275,25 +282,42 @@
     return ctx;
   };
 
+
   /**
-   * Dispatch the given `ctx`.
+   * Dispatch the exit routes for current `ctx`.
+   *
+   * @param {Object} ctx
+   * @param {Function} cb
+   * @api private
+   */
+
+  page.dispatchExit = function (ctx, cb) {
+    var prev = prevContext,
+      i = 0;
+    prevContext = ctx;
+
+    function nextExit() {
+      var fn = page.exits[i++];
+      if (!fn) return cb();
+      fn(prev, nextExit);
+    }
+
+    if (prev) {
+      nextExit();
+    } else {
+      cb();
+    }
+  };
+
+  /**
+   * Dispatch the entry routes for `ctx`.
    *
    * @param {Object} ctx
    * @api private
    */
 
-  page.dispatch = function(ctx) {
-    var prev = prevContext,
-      i = 0,
-      j = 0;
-
-    prevContext = ctx;
-
-    function nextExit() {
-      var fn = page.exits[j++];
-      if (!fn) return nextEnter();
-      fn(prev, nextExit);
-    }
+  page.dispatchEnter = function(ctx) {
+    var i = 0;
 
     function nextEnter() {
       var fn = page.callbacks[i++];
@@ -306,11 +330,20 @@
       fn(ctx, nextEnter);
     }
 
-    if (prev) {
-      nextExit();
-    } else {
-      nextEnter();
-    }
+    nextEnter();
+  };
+
+  /**
+   * Dispatch all routes for 'ctx'
+   *
+   * @param {Object} ctx
+   * @api private
+   */
+
+  page.dispatch = function(ctx) {
+    page.dispatchExit(ctx, function () {
+      page.dispatchEnter(ctx);
+    });
   };
 
   /**

--- a/test/tests.js
+++ b/test/tests.js
@@ -168,6 +168,45 @@
           page('/bootstrap');
           page('/');
         });
+
+        it('should not call further route handlers if an exit route interrupts', function () {
+          var routes = [];
+          page('/before', function () {});
+          page('/after', function () {
+            routes.push('arrived');
+          });
+          page.exit('/before', function (ctx, next) {
+            routes.push('one');
+            next();
+          });
+          page.exit('/before', function (ctx, next) {
+            routes.push('two');
+            // Note absence of next() call.
+          });
+          page.exit('/before', function (ctx, next) {
+            routes.push('three');
+            next();
+          });
+          page('/before');
+          routes = [];
+          page('/after');
+          expect(routes.join(' ')).to.equal('one two');
+        });
+
+        it('should not update the current history location if exit route interrupts', function () {
+          page('/before', function (ctx, next) {});
+          page('/after', function (ctx, next) {});
+          page.exit('/before', function (ctx, next) {
+            expect(ctx.path).to.equal('/before');
+            // Note absence of next() call.
+          });
+          page('/before');
+          page('/after');
+          var path = hashbang
+            ? location.hash.replace('#!', '')
+            : location.pathname;
+          expect(path).to.equal('/before');
+        });
       });
 
       describe('page.back', function() {


### PR DESCRIPTION
Rewired the dispatch function into two separate functions, one for exit routes, on for entry routes. The exit dispatcher takes a callback which is called or not depending on every exit handler calling next. If exit handlers do not pass, then page.show will not update the history. the dispatch() function itself will now first run all exits, then entries as a callback.

Not completely sure how best to handle page.redirect and page.replace in this context - so for the moment they just call dispatch() as before. I'll gladly amend this PR if there are good suggestions for correct behavior there.