### PR TITLE
add a flag to state that specifies if this transition was the result of a popstate event

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,6 +526,7 @@
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;
+        e.state.popstate = true;
         page.replace(path, e.state);
       } else {
         page.show(location.pathname + location.hash, undefined, undefined, false);

--- a/page.js
+++ b/page.js
@@ -528,6 +528,7 @@
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;
+        e.state.popstate = true;
         page.replace(path, e.state);
       } else {
         page.show(location.pathname + location.hash, undefined, undefined, false);

--- a/test/tests.js
+++ b/test/tests.js
@@ -190,6 +190,19 @@
           page.back('/first');
           expect(page.len).to.be.equal(lenAtFirst);
         });
+        it('should define popstate on the state', function(done) {
+          var firstTime = true;
+          page('/third', function(ctx) {
+              if (!firstTime) {
+                  expect(ctx.state.popstate).to.be.true;
+                  done();
+              }
+              firstTime = false;
+          });
+          page('/third');
+          page('/second');
+          page.back();
+        });
       });
 
       describe('ctx.querystring', function() {


### PR DESCRIPTION
This pull request defines a boolean 'popstate' to context.state that is true if the transition came from an onpopstate handler.

What this lets you figure out is that the transition was the result of navigating the page history (browser back, history.back()) rather than a normal navigation. My specific need for this arose from having to deal with browser inconsistencies with respect to [restoring scroll position](http://stackoverflow.com/a/12045150) on a popstate event.