### PR TITLE
Fix double back issue

### DIFF
--- a/page.js
+++ b/page.js
@@ -426,7 +426,17 @@
    */
 
   Context.prototype.save = function() {
-    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    var self = this;
+
+    /*
+     * Wrap history.replaceState in a setTimeout to allow the dispatching queue
+     * to flush out and change the URL before we save. Otherwise a
+     * context.save() in a route handler will replace the state using the wrong
+     * URL! See: https://github.com/visionmedia/page.js/issues/230
+     */
+    setTimeout(function () {
+      history.replaceState(self.state, self.title, hashbang && self.path !== '/' ? '#!' + self.path : self.canonicalPath);
+    }, 0);
   };
 
   /**


### PR DESCRIPTION
This can be reproduced by going to the examples/state/app.js and removing the setTimeout from the load function. The setTimeout in the example effectively works around this bug by allowing the dispatching queue to finish.

Refs #230 
