### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "page",
   "description": "Tiny client-side router",
   "version": "1.6.3",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/visionmedia/page.js.git"


### PR DESCRIPTION
actually add license

reported by http://npm1k.org
NPM recently updated its guidelines (npm@v2.10+) on license metadata in package.json files.