### PR TITLE
Adding onhashchange option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,6 +136,7 @@ page('/default');
 
   - `click` bind to click events [__true__]
   - `popstate` bind to popstate [__true__]
+  - 'hashchange' bind to hashchange [__false__]
   - `dispatch` perform initial dispatch [__true__]
   - `hashbang` add `#!` before urls [__false__]
   - `decodeURLComponents` remove URL encoding from path components (query string, pathname, hash) [__true__]

--- a/index.js
+++ b/index.js
@@ -159,6 +159,7 @@
     if (false === options.dispatch) dispatch = false;
     if (false === options.decodeURLComponents) decodeURLComponents = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
+    if (true === options.hashchange) window.addEventListener('hashchange', onpopstate, false);
     if (false !== options.click) {
       document.addEventListener(clickEvent, onclick, false);
     }

--- a/page.js
+++ b/page.js
@@ -161,6 +161,7 @@
     if (false === options.dispatch) dispatch = false;
     if (false === options.decodeURLComponents) decodeURLComponents = false;
     if (false !== options.popstate) window.addEventListener('popstate', onpopstate, false);
+    if (true === options.hashchange) window.addEventListener('hashchange', onpopstate, false);
     if (false !== options.click) {
       document.addEventListener(clickEvent, onclick, false);
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -418,6 +418,20 @@
 
   });
 
+  describe('hashchange option enabled', function() {
+    before(function() {
+      beforeTests({
+        hashchange: true
+      });
+    });
+
+    tests();
+
+    after(function() {
+      afterTests();
+    });
+  });
+
   describe('Different Base', function() {
 
     before(function() {


### PR DESCRIPTION
Allowing attaching the popstate event handler to onhashchange to support hash-based routes in IE.

The hashchange option by default is disabled, and the  event will only be attached if hashchange: true is passed in with the options.
