### PR TITLE
Fixed hash change listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,10 @@
     if (false !== options.click) {
       document.addEventListener(clickEvent, onclick, false);
     }
-    if (true === options.hashbang) hashbang = true;
+    if (true === options.hashbang) {
+      hashbang = true;
+      window.addEventListener('hashchange', onhashchange, false);
+    }
     if (!dispatch) return;
     var url = (hashbang && ~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
     page.replace(url, null, true, dispatch);
@@ -181,6 +184,7 @@
     running = false;
     document.removeEventListener(clickEvent, onclick, false);
     window.removeEventListener('popstate', onpopstate, false);
+    window.removeEventListener('hashchange', onhashchange, false);
   };
 
   /**
@@ -325,7 +329,7 @@
     var current;
 
     if (hashbang) {
-      current = base + location.hash.replace('#!', '');
+      current = location.pathname + location.hash;
     } else {
       current = location.pathname + location.search;
     }
@@ -532,6 +536,16 @@
       }
     };
   })();
+
+  /**
+   * Handle "hash" events.
+   */
+
+   var onhashchange = function () {
+     var url = (~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
+     page.replace(url, null, true, dispatch);
+   };
+
   /**
    * Handle "click" events.
    */


### PR DESCRIPTION
Hi there!

First of all thanks for a great library! I have wrapped Page JS to become a reactive router, read more here: https://github.com/christianalfoni/reactive-router.

When developing this I discovered a bug. When using "hashbangs" and manually changing the url in the address bar does not trigger a route. Looking into the code I did not find the "hashchange" listener, so I added it. This did not initially work because at the `unhandled` function, when setting the `current` variable it is not compatible with the `canonicalPath` as that includes the hashbang, but that was removed for some reason?

I have done as many tests as I can, but could not figure out how to write a node test for this... can not really do that.

So yeah, hopefully my changes makes sense and it works out!