### PR TITLE
Solve shadow-dom clicks and hashband address bar fix

### DIFF
--- a/page.js
+++ b/page.js
@@ -384,6 +384,8 @@
     this.path = path.replace(base, '') || '/';
     if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
+    if (this.path.indexOf('//') === 0) this.path = this.path.replace('//', '/');
+
     this.title = document.title;
     this.state = state || {};
     this.state.path = path;
@@ -548,8 +550,11 @@
 
 
     // ensure link
-    var el = e.target;
-    while (el && 'A' !== el.nodeName) el = el.parentNode;
+    var i = 0,
+       path = e.path || false,
+       el = path ? e.path[i] : e.target;
+
+    while (el && 'A' !== el.nodeName) el = path ? e.path[++i] : el.parentElement;
     if (!el || 'A' !== el.nodeName) return;
 
 


### PR DESCRIPTION
Now, the clicks routing events works in shadow-dom.

Change a route with hashband:true in the address bar is fixed.
