### PR TITLE
Migrate from Travis legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js: ["0.10"]
 after_success:
   - ./node_modules/.bin/jscoverage index.js index-cov.js
   - PAGE_COV=1 ./node_modules/.bin/mocha test/tests.js -R mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js
+sudo: false


### PR DESCRIPTION
Travis recommends use container-based infrastructure over legacy one. All info at Travis Docs: [Migrating from legacy](http://docs.travis-ci.com/user/migrating-from-legacy/)
