### PR TITLE
Allow passing in the title from state

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,8 +382,8 @@
     this.path = path.replace(base, '') || '/';
     if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
-    this.title = document.title;
     this.state = state || {};
+    this.title = this.state.title || document.title;
     this.state.path = path;
     this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
     this.pathname = decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);


### PR DESCRIPTION
This would allow me to pass in "title" from "state". Furthermore, if I do so, I can avoid the dependency on `document` and use page.js to route server-side rendering.

