### PR TITLE
Allow override page.sameOrigin

### DIFF
--- a/index.js
+++ b/index.js
@@ -570,7 +570,7 @@
     if (el.target) return;
 
     // x-origin
-    if (!sameOrigin(el.href)) return;
+    if (!page.sameOrigin(el.href)) return;
 
 
 


### PR DESCRIPTION
In some cases, the sameOrigin function is not working properly, for example, in QtWebEngine with qrc: protocol. It would be great if this function could override. This pull request just adds support for this. Thank you.
