### PR TITLE
More prep for 1.6.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+1.6.4 / 2015-10-09
+==================
+
+* fix wildcard route support (update path-to-regexp to v1.2.1)
+
 1.6.3 / 2015-04-19
 ==================
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -346,17 +346,15 @@
 
         describe('when next() is invoked', function() {
           it('should invoke subsequent matching middleware', function(done) {
+
+            var visistedFirst = false;
             page('/forum/*', function(ctx, next) {
-              ctx.fullPath = ctx.params[0];
+              visistedFirst = true;
               next();
             });
 
-            page('/user', function() {
-
-            });
-
             page('/forum/:fid/thread/:tid', function(ctx) {
-              expect(ctx.params.tid).to.equal('2');
+              expect(visistedFirst).to.equal(true);
               done();
             });
 


### PR DESCRIPTION
Fixed the only test which exercised a non-`'*'` wildcard route (which wasn't actually testing anything it was supposed to) and updated History.md