### PR TITLE
Support error-handling through function arity.

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,9 @@
   function page(path, fn) {
     // <callback>
     if ('function' === typeof path) {
-      return page('*', path);
+      var args = ['*'];
+      Array.prototype.push.apply(args, arguments);
+      return page.apply(this, args);
     }
 
     // route <path> to <callback ...>

--- a/page.js
+++ b/page.js
@@ -87,7 +87,9 @@
   function page(path, fn) {
     // <callback>
     if ('function' === typeof path) {
-      return page('*', path);
+      var args = ['*'];
+      Array.prototype.push.apply(args, arguments);
+      return page.apply(this, args);
     }
 
     // route <path> to <callback ...>


### PR DESCRIPTION
Two commits here:

First catches what I perceive as a bug, i.e. that leaving out the path should support multiple callbacks.

Second uses the callback's arity to decide whether the callback is an error-handler and, if so, only invoke it in the presence of an error (i.e. `next(new Error('Ugh.'));`).  This mimics Express behavior.

Alternatively, the second change could be implemented by removing Route#middleware entirely.  One would then push the entire Route object into the `callbacks` and `exits` arrays and perform the matches check in `nextEnter` and `nextExit`.  This approach feels cleaner to me but seemed less aligned with the current design, hence the changes here.

If you'd like me to post the alternative approach, just let me know. 