### PR TITLE
Link Click issue

### DIFF
--- a/page.js
+++ b/page.js
@@ -578,7 +578,7 @@
 
 
     // rebuild path
-    var path = el.pathname + el.search + (el.hash || '');
+    var path = (el.pathname == '/' ? '' : el.pathname) + el.search + (el.hash || '');
 
     // strip leading "/[drive letter]:" on NW.js on Windows
     if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {


### PR DESCRIPTION
When we change the url hash using anchor link, the path is generated like so
el.pathname + el.search + (el.hash || '');
If we are at the  root, el.path = '/'. Path generated = '//something'.
matching route should be
page('//something', callback). However hashbang remain '#!/something'. This is very misleading so changed for the root path. Not sure about other sub path cases.
