### PR TITLE
Fix reloading issue when using hashbang

### DIFF
--- a/page.js
+++ b/page.js
@@ -382,7 +382,7 @@
 
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
-    if (hashbang) this.path = this.path.replace('#!', '') || '/';
+    if (hashbang) this.path = this.path.replace('#!/', '') || '/';
 
     this.title = document.title;
     this.state = state || {};


### PR DESCRIPTION
If the `/` is not replaced, it results in a double `//` in the url, causing a 404.

Fixes #304

Closes #301 
Closes #281