### PR TITLE
Reinstate shadow DOM fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -548,7 +548,8 @@
 
 
     // ensure link
-    var el = e.target;
+    // use shadow dom when available
+    var el = e.path ? e.path[0] : e.target;
     while (el && 'A' !== el.nodeName) el = el.parentNode;
     if (!el || 'A' !== el.nodeName) return;
 


### PR DESCRIPTION
PR #284 was made against page.js, not index.js, so they were overridden when doing `npm publish`.

https://github.com/visionmedia/page.js/commit/00899e6c0c0b7e45b1f1962709c58b91ceec9812#commitcomment-16690945