### PR TITLE
Make match respect decodeURLComponents option

### DIFF
--- a/index.js
+++ b/index.js
@@ -490,7 +490,7 @@
     var keys = this.keys,
       qsIndex = path.indexOf('?'),
       pathname = ~qsIndex ? path.slice(0, qsIndex) : path,
-      m = this.regexp.exec(decodeURIComponent(pathname));
+      m = this.regexp.exec(decodeURLEncodedURIComponent(pathname));
 
     if (!m) return false;
 


### PR DESCRIPTION
Every other place that has decoding the
decodeURLEncodedURIComponent function is used
so that the option is respected.

This commit makes it so that in this location it
occurs as well.