### PR TITLE
remove hash from ctx.pathname

### DIFF
--- a/page.js
+++ b/page.js
@@ -401,6 +401,7 @@
       this.path = parts[0];
       this.hash = decodeURLEncodedURIComponent(parts[1]) || '';
       this.querystring = this.querystring.split('#')[0];
+      this.pathname = this.pathname.split('#')[0];
     }
   }
 


### PR DESCRIPTION
Fixes #375 by removing hashportion of pathname the same way it's done for ctx.path.
Maybe Route.prototype.match also needs to be updated ... not sure about this.