### PR TITLE
Update document title on context pushState

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,7 +564,11 @@
     var link = el.getAttribute('href');
     if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
-
+    // prevent handling links with the same url
+    if (el.pathname === location.pathname) {
+      e.preventDefault();
+      return;
+    }
 
     // Check for mailto: in the href
     if (link && link.indexOf('mailto:') > -1) return;

--- a/index.js
+++ b/index.js
@@ -565,7 +565,7 @@
     if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
     // prevent handling links with the same url
-    if (el.pathname === location.pathname) {
+    if (el.pathname + el.search === location.pathname + location.search) {
       e.preventDefault();
       return;
     }

--- a/page.js
+++ b/page.js
@@ -419,6 +419,7 @@
   Context.prototype.pushState = function() {
     page.len++;
     history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    document.title = this.title;
   };
 
   /**
@@ -429,6 +430,7 @@
 
   Context.prototype.save = function() {
     history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    document.title = this.title;
   };
 
   /**

--- a/page.js
+++ b/page.js
@@ -569,7 +569,7 @@
     if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
     // prevent handling links with the same url
-    if (el.pathname === location.pathname) {
+    if (el.pathname + el.search === location.pathname + location.search) {
       e.preventDefault();
       return;
     }

--- a/page.js
+++ b/page.js
@@ -568,7 +568,11 @@
     var link = el.getAttribute('href');
     if (!hashbang && el.pathname === location.pathname && (el.hash || '#' === link)) return;
 
-
+    // prevent handling links with the same url
+    if (el.pathname === location.pathname) {
+      e.preventDefault();
+      return;
+    }
 
     // Check for mailto: in the href
     if (link && link.indexOf('mailto:') > -1) return;


### PR DESCRIPTION
When you run the pushState, browser actually sets current document.title as a title of previous state. Therefore, it's not possible to change document title from within a router, because it will cause wrong title in the history.

Here's how you can check it:
1. Create two routers – page1 and page2. They should be setting document.title.
2. Navigate to page1.
3. Navigate to page2.
4. Now hold the mouse button over the back button. You'll see the following: "page2 (page1.html)"

The solution is to modify context's title from a router and then set that title after pushState.

Here's the related issue: https://github.com/visionmedia/page.js/issues/355
