### PR TITLE
added check for undefined fn

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@
         page.callbacks.push(route.middleware(arguments[i]));
       }
       // show <path> with [state]
-    } else if ('string' === typeof path) {
+    } else if ('string' === typeof path && fn !== undefined) {
       page['string' === typeof fn ? 'redirect' : 'show'](path, fn);
       // start [options]
     } else {


### PR DESCRIPTION
If fn is undefined, page() constructor should fall into page.start - not 'show' which assumed fn is defined and the valid state.