### PR TITLE
Correctly handle clicks from svg links

### DIFF
--- a/index.js
+++ b/index.js
@@ -551,13 +551,12 @@
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
 
-    // check if link is inside an svg | in this case, both href and target are always inside an object
-    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
-
     // continue ensure link | el.nodeName for svg links are 'a' instead of 'A' and fail when testing only in the latter
     while (el && ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) el = el.parentNode;
     if (!el || ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) return;
 
+    // check if link is inside an svg | in this case, both href and target are always inside an object
+    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
 
 
     // Ignore if tag has

--- a/index.js
+++ b/index.js
@@ -550,8 +550,13 @@
     // ensure link
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
-    while (el && 'A' !== el.nodeName) el = el.parentNode;
-    if (!el || 'A' !== el.nodeName) return;
+
+    // check if link is inside an svg | in this case, both href and target are always inside an object
+    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
+
+    // continue ensure link | el.nodeName for svg links are 'a' instead of 'A' and fail when testing only in the latter
+    while (el && ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) el = el.parentNode;
+    if (!el || ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) return;
 
 
 
@@ -570,15 +575,20 @@
     if (link && link.indexOf('mailto:') > -1) return;
 
     // check target
-    if (el.target) return;
+    // svg target is an object and its desired value is in .baseVal property
+    if ( svg ? el.target.baseVal : el.target ) return;
 
     // x-origin
-    if (!sameOrigin(el.href)) return;
+    // note: svg links that are not relative don't call click events (and skip page.js)
+    // consequently, all svg links tested inside page.js are relative and in the same origin
+    if ( !svg && !sameOrigin( el.href )) return;
 
 
 
     // rebuild path
-    var path = el.pathname + el.search + (el.hash || '');
+    // There aren't .pathname and .search properties in svg links, so we use href
+    // Also, svg href is an object and its desired value is in .baseVal property
+    var path = svg ? el.href.baseVal : ( el.pathname + el.search + (el.hash || '') );
 
     // strip leading "/[drive letter]:" on NW.js on Windows
     if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {

--- a/page.js
+++ b/page.js
@@ -553,12 +553,12 @@
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
 
-    // check if link is inside an svg | in this case, both href and target are always inside an object
-    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
-
     // continue ensure link | el.nodeName for svg links are 'a' instead of 'A' and fail when testing only in the latter
     while (el && ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) el = el.parentNode;
     if (!el || ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) return;
+
+    // check if link is inside an svg | in this case, both href and target are always inside an object
+    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
 
 
 

--- a/page.js
+++ b/page.js
@@ -552,8 +552,13 @@
     // ensure link
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
-    while (el && 'A' !== el.nodeName) el = el.parentNode;
-    if (!el || 'A' !== el.nodeName) return;
+
+    // check if link is inside an svg | in this case, both href and target are always inside an object
+    var svg = ( typeof el.href === 'object' ) && el.href.constructor.name === 'SVGAnimatedString';
+
+    // continue ensure link | el.nodeName for svg links are 'a' instead of 'A' and fail when testing only in the latter
+    while (el && ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) el = el.parentNode;
+    if (!el || ( 'A' !== el.nodeName && 'a' !== el.nodeName ) ) return;
 
 
 
@@ -572,15 +577,20 @@
     if (link && link.indexOf('mailto:') > -1) return;
 
     // check target
-    if (el.target) return;
+    // svg target is an object and its desired value is in .baseVal property
+    if ( svg ? el.target.baseVal : el.target ) return;
 
     // x-origin
-    if (!sameOrigin(el.href)) return;
+    // note: svg links that are not relative don't call click events (and skip page.js)
+    // consequently, all svg links tested inside page.js are relative and in the same origin
+    if ( !svg && !sameOrigin( el.href )) return;
 
 
 
     // rebuild path
-    var path = el.pathname + el.search + (el.hash || '');
+    // There aren't .pathname and .search properties in svg links, so we use href
+    // Also, svg href is an object and its desired value is in .baseVal property
+    var path = svg ? el.href.baseVal : ( el.pathname + el.search + (el.hash || '') );
 
     // strip leading "/[drive letter]:" on NW.js on Windows
     if (typeof process !== 'undefined' && path.match(/^\/[a-zA-Z]:\//)) {


### PR DESCRIPTION
**What it is:**
An improvement to onclick function, to correctly handle svg links too.
 - without compromising non-svg links
 - using and respecting the same checks, e.g. target and external checking
 - no duplication of code, because the same lines are compatible with svg and non-svg links now

**Why it is needed:**
To make projects that use SVG links compatible with page.js
 - SVG support is [a standard](http://caniuse.com/#feat=svg)
 - Web and mobile projects with UI based on SVG are [awesome](http://slides.com/sarasoueidan/building-better-interfaces-with-svg)!