### PR TITLE
Add duplicate exports to avoid aliases for Closure-compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@
    */
 
   module.exports = page;
+  module.exports.Context = Context;
+  module.exports.Route = Route;
+  module.exports.sameOrigin = sameOrigin;
 
   /**
    * Detect click event


### PR DESCRIPTION
I've recently done a lot of work on Closure-compiler to improve handling of CommonJS modules. The compiler still has a hard time with the indirection caused by:

```js
// Page.js
module.exports = page;
page.Context = Context;
function Context() {}
```

The compiler has a hard time unwinding all the aliases. Simply adding the explicit export statements for the static properties completely alleviates the issue.