### PR TITLE
Added missing `location.search` for onpopstate

### DIFF
--- a/index.js
+++ b/index.js
@@ -530,7 +530,7 @@
         var path = e.state.path;
         page.replace(path, e.state);
       } else {
-        page.show(location.pathname + location.hash, undefined, undefined, false);
+        page.show(location.pathname + location.search + location.hash, undefined, undefined, false);
       }
     };
   })();

--- a/page.js
+++ b/page.js
@@ -532,7 +532,7 @@
         var path = e.state.path;
         page.replace(path, e.state);
       } else {
-        page.show(location.pathname + location.hash, undefined, undefined, false);
+        page.show(location.pathname + location.search + location.hash, undefined, undefined, false);
       }
     };
   })();


### PR DESCRIPTION
There was a missing `location.search` in `onpopstate`, which could cause users to be redirected with the query missing