### PR TITLE
Small fix to prevent errors referencing `history` on node.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -416,7 +416,9 @@
 
   Context.prototype.pushState = function() {
     page.len++;
-    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    if(typeof history !== 'undefined') {
+      history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    }
   };
 
   /**
@@ -426,7 +428,9 @@
    */
 
   Context.prototype.save = function() {
-    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    if(typeof history !== 'undefined') {
+      history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    }
   };
 
   /**


### PR DESCRIPTION
Simple if clause to avoid use of `window.history` if the history object is not available. Allows for simple routing with node.js.