### PR TITLE
Added option to disable baseUrl in pathname

### DIFF
--- a/page.js
+++ b/page.js
@@ -58,6 +58,12 @@
    */
 
   var hashbang = false;
+  
+  /**
+   * BaseUrlInPathname option
+   */
+
+  var baseUrlInPathname = true;
 
   /**
    * Previous context, for capturing
@@ -165,6 +171,7 @@
       document.addEventListener(clickEvent, onclick, false);
     }
     if (true === options.hashbang) hashbang = true;
+    if (false === options.baseUrlInPathname) baseUrlInPathname = false;
     if (!dispatch) return;
     var url = (hashbang && ~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
     page.replace(url, null, true, dispatch);
@@ -596,7 +603,7 @@
 
     if (hashbang) path = path.replace('#!', '');
 
-    if (base && orig === path) return;
+    if (baseUrlInPathname && base && orig === path) return;
 
     e.preventDefault();
     page.show(orig);


### PR DESCRIPTION
I think it's terrible to force explicitly mentioning the baseUrl in every href. I propose adding the option `baseUrlInPathname`. I set its default value to `true`, so it won't break anything.