### PR TITLE
mark loaded true when DOMContentLoaded

### DIFF
--- a/page.js
+++ b/page.js
@@ -517,10 +517,10 @@
     if ('undefined' === typeof window) {
       return;
     }
-    if (document.readyState === 'complete') {
+    if (document.readyState === 'interactive') {
       loaded = true;
     } else {
-      window.addEventListener('load', function() {
+      document.addEventListener('DOMContentLoaded', function() {
         setTimeout(function() {
           loaded = true;
         }, 0);


### PR DESCRIPTION
let's say there are two routes A and B in the same HTML file H .
and there are some time-consuming ajax in H
if I route from A to B `page.redirect('/B')`, that's ok.
but when I run `history.back()`

**it can't back to A**

I found that onpopstate worked when `window.onload` 
I think `DOMContentLoaded` is already ok.