### PR TITLE
Feat: Allow use of hash instead of hashbang

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,7 +131,7 @@ page('/default');
   - `click` bind to click events [__true__]
   - `popstate` bind to popstate [__true__]
   - `dispatch` perform initial dispatch [__true__]
-  - `hashbang` add `#!` before urls [__false__]
+  - `hashbang` add `#!` before urls when __true__, or add `#` when __"#"__ [__false__]
   - `decodeURLComponents` remove URL encoding from path components (query string, pathname, hash) [__true__]
 
   If you wish to load serve initial content

--- a/index.js
+++ b/index.js
@@ -58,6 +58,12 @@
   var hashbang = false;
 
   /**
+   * Hash character
+   */
+
+  var hashChar;
+
+  /**
    * Previous context, for capturing
    * page exit events.
    */
@@ -162,9 +168,12 @@
     if (false !== options.click) {
       document.addEventListener(clickEvent, onclick, false);
     }
-    if (true === options.hashbang) hashbang = true;
+    if (true === options.hashbang || '#' === options.hashbang) {
+      hashbang = true;
+      hashChar = ('#' === options.hashbang) ? '#' : '#!';
+    }
     if (!dispatch) return;
-    var url = (hashbang && ~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
+    var url = (hashbang && ~location.hash.indexOf(hashChar)) ? location.hash.substr(hashChar.length) + location.search : location.pathname + location.search + location.hash;
     page.replace(url, null, true, dispatch);
   };
 
@@ -326,7 +335,7 @@
     var current;
 
     if (hashbang) {
-      current = base + location.hash.replace('#!', '');
+      current = base + location.hash.replace(hashChar, '');
     } else {
       current = location.pathname + location.search;
     }
@@ -377,12 +386,12 @@
    */
 
   function Context(path, state) {
-    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? '#!' : '') + path;
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? hashChar : '') + path;
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
-    if (hashbang) this.path = this.path.replace('#!', '') || '/';
+    if (hashbang) this.path = this.path.replace(hashChar, '') || '/';
 
     this.title = (typeof document !== 'undefined' && document.title);
     this.state = state || {};
@@ -416,7 +425,7 @@
 
   Context.prototype.pushState = function() {
     page.len++;
-    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? hashChar + this.path : this.canonicalPath);
   };
 
   /**
@@ -426,7 +435,7 @@
    */
 
   Context.prototype.save = function() {
-    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? hashChar + this.path : this.canonicalPath);
   };
 
   /**
@@ -592,7 +601,7 @@
       path = path.substr(base.length);
     }
 
-    if (hashbang) path = path.replace('#!', '');
+    if (hashbang) path = path.replace(hashChar, '');
 
     if (base && orig === path) return;
 

--- a/page.js
+++ b/page.js
@@ -60,6 +60,12 @@
   var hashbang = false;
 
   /**
+   * Hash character
+   */
+
+  var hashChar;
+
+  /**
    * Previous context, for capturing
    * page exit events.
    */
@@ -164,9 +170,12 @@
     if (false !== options.click) {
       document.addEventListener(clickEvent, onclick, false);
     }
-    if (true === options.hashbang) hashbang = true;
+    if (true === options.hashbang || '#' === options.hashbang) {
+      hashbang = true;
+      hashChar = ('#' === options.hashbang) ? '#' : '#!';
+    }
     if (!dispatch) return;
-    var url = (hashbang && ~location.hash.indexOf('#!')) ? location.hash.substr(2) + location.search : location.pathname + location.search + location.hash;
+    var url = (hashbang && ~location.hash.indexOf(hashChar)) ? location.hash.substr(hashChar.length) + location.search : location.pathname + location.search + location.hash;
     page.replace(url, null, true, dispatch);
   };
 
@@ -328,7 +337,7 @@
     var current;
 
     if (hashbang) {
-      current = base + location.hash.replace('#!', '');
+      current = base + location.hash.replace(hashChar, '');
     } else {
       current = location.pathname + location.search;
     }
@@ -379,14 +388,14 @@
    */
 
   function Context(path, state) {
-    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? '#!' : '') + path;
+    if ('/' === path[0] && 0 !== path.indexOf(base)) path = base + (hashbang ? hashChar : '') + path;
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
     this.path = path.replace(base, '') || '/';
-    if (hashbang) this.path = this.path.replace('#!', '') || '/';
+    if (hashbang) this.path = this.path.replace(hashChar, '') || '/';
 
-    this.title = document.title;
+    this.title = (typeof document !== 'undefined' && document.title);
     this.state = state || {};
     this.state.path = path;
     this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
@@ -418,7 +427,7 @@
 
   Context.prototype.pushState = function() {
     page.len++;
-    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    history.pushState(this.state, this.title, hashbang && this.path !== '/' ? hashChar + this.path : this.canonicalPath);
   };
 
   /**
@@ -428,7 +437,7 @@
    */
 
   Context.prototype.save = function() {
-    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+    history.replaceState(this.state, this.title, hashbang && this.path !== '/' ? hashChar + this.path : this.canonicalPath);
   };
 
   /**
@@ -594,7 +603,7 @@
       path = path.substr(base.length);
     }
 
-    if (hashbang) path = path.replace('#!', '');
+    if (hashbang) path = path.replace(hashChar, '');
 
     if (base && orig === path) return;
 
@@ -624,7 +633,7 @@
   page.sameOrigin = sameOrigin;
 
 }).call(this,require('_process'))
-},{"_process":2,"path-to-regexp":3}],2:[function(require,module,exports){
+},{"_process":2,"path-to-regexp":4}],2:[function(require,module,exports){
 // shim for using process in browser
 
 var process = module.exports = {};
@@ -713,6 +722,11 @@ process.chdir = function (dir) {
 };
 
 },{}],3:[function(require,module,exports){
+module.exports = Array.isArray || function (arr) {
+  return Object.prototype.toString.call(arr) == '[object Array]';
+};
+
+},{}],4:[function(require,module,exports){
 var isarray = require('isarray')
 
 /**
@@ -1104,10 +1118,5 @@ function pathToRegexp (path, keys, options) {
   return stringToRegexp(path, keys, options)
 }
 
-},{"isarray":4}],4:[function(require,module,exports){
-module.exports = Array.isArray || function (arr) {
-  return Object.prototype.toString.call(arr) == '[object Array]';
-};
-
-},{}]},{},[1])(1)
+},{"isarray":3}]},{},[1])(1)
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -9,6 +9,7 @@
     html = '',
     base = '',
     hashbang = false,
+    hashChar = '#!',
     decodeURLComponents = true,
     chai = this.chai,
     expect = this.expect,
@@ -180,7 +181,7 @@
         it('should move back to history', function() {
           page.back('/first');
           var path = hashbang
-            ? location.hash.replace('#!', '')
+            ? location.hash.replace(hashChar, '')
             : location.pathname;
           expect(path).to.be.equal('/first');
         });
@@ -224,7 +225,7 @@
       describe('ctx.pathname', function() {
         it('should default to ctx.path', function(done) {
           page('/pathname-default', function(ctx) {
-            expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') + '/pathname-default');
+            expect(ctx.pathname).to.equal(base + (base && hashbang ? hashChar : '') + '/pathname-default');
             done();
           });
 
@@ -233,7 +234,7 @@
 
         it('should omit the query string', function(done) {
           page('/pathname', function(ctx) {
-            expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') + '/pathname');
+            expect(ctx.pathname).to.equal(base + (base && hashbang ? hashChar : '') + '/pathname');
             done();
           });
 
@@ -242,7 +243,7 @@
 
         it('should accommodate URL encoding', function(done) {
           page('/long path with whitespace', function(ctx) {
-            expect(ctx.pathname).to.equal(base + (base && hashbang ? '#!' : '') +
+            expect(ctx.pathname).to.equal(base + (base && hashbang ? hashChar : '') +
               (decodeURLComponents ? '/long path with whitespace' : '/long%20path%20with%20whitespace'));
             done();
           });
@@ -395,6 +396,42 @@
 
     after(function() {
       afterTests();
+    });
+
+  });
+
+  describe('Hashbang option set incorrectly does nothing', function() {
+
+    before(function() {
+      hashbang = false;
+      beforeTests({
+        hashbang: '##',
+      });
+    });
+
+    tests();
+
+    after(function() {
+      afterTests();
+    });
+
+  });
+
+  describe('Hashbang option set to hash', function() {
+
+    before(function() {
+      hashbang = hashChar = '#';
+      beforeTests({
+        hashbang: hashbang,
+      });
+    });
+
+    tests();
+
+    after(function() {
+      afterTests();
+      hashbang = false;
+      hashChar = '#!';
     });
 
   });


### PR DESCRIPTION
This PR allows users to set the `hashbang` option to '#' in addition to `true`. This allows users to use a simple hash for routing, instead of just the hashbang. 

- `hashbang: true` - existing functionality, use `#!`
- `hashbang: '#'` - similar functionality, but use `#` instead of `#!`
- `hashbang: <anything else>` - hashbang is disabled

Adds tests for using `#` (new functionality) and `##` (invalid value, hashbang disabled).

I considered adding this functionality as a new option, and possibly renaming `hashbang` to `hash` or `useHash`, but going that far would be a breaking API change. This seemed simpler, but I'm open to changing how this functionality is exposed.