### PR TITLE
Prevent similar looking domains to trigger page callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -579,7 +579,7 @@
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
 
-    // continue ensure link 
+    // continue ensure link
     // el.nodeName for svg links are 'a' instead of 'A'
     while (el && 'A' !== el.nodeName.toUpperCase()) el = el.parentNode;
     if (!el || 'A' !== el.nodeName.toUpperCase()) return;
@@ -646,13 +646,33 @@
   }
 
   /**
+   * Convert to a URL object
+   */
+  function toURL(href) {
+    if(typeof URL === "function") {
+      if(href.indexOf("http") !== 0) {
+        return new URL(href, "http://example.com");
+      }
+
+      return new URL(href);
+    } else {
+      var anc = document.createElement("a");
+      anc.href = href;
+      return anc;
+    }
+  }
+
+  /**
    * Check if `href` is the same origin.
    */
 
   function sameOrigin(href) {
-    var origin = location.protocol + '//' + location.hostname;
-    if (location.port) origin += ':' + location.port;
-    return (href && (0 === href.indexOf(origin)));
+    if(!href) return false;
+    var url = toURL(href);
+
+    return location.protocol === url.protocol &&
+      location.hostname === url.hostname &&
+      location.port === url.port;
   }
 
   page.sameOrigin = sameOrigin;

--- a/index.js
+++ b/index.js
@@ -649,14 +649,10 @@
    * Convert to a URL object
    */
   function toURL(href) {
-    if(typeof URL === "function") {
-      if(href.indexOf("http") !== 0) {
-        return new URL(href, "http://example.com");
-      }
-
-      return new URL(href);
+    if(typeof URL === 'function') {
+      return new URL(href, location.toString());
     } else {
-      var anc = document.createElement("a");
+      var anc = document.createElement('a');
       anc.href = href;
       return anc;
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -43,6 +43,7 @@
           bubbles: true,
           button: 1
         });
+        Object.defineProperty(event, 'which', { value: null });
       } else {
         event = document.createEvent('MouseEvents');
 
@@ -86,6 +87,7 @@
       html += '      <li><a class="contact" href="./contact">/contact</a></li>';
       html += '      <li><a class="contact-me" href="./contact/me">/contact/me</a></li>';
       html += '      <li><a class="not-found" href="./not-found?foo=bar">/not-found</a></li>';
+      html += '      <li><a class="diff-domain" href="http://example.com.uk/diff/domain">another domain</a></li>';
       html += '</ul>';
 
       htmlWrapper.innerHTML = html;
@@ -405,6 +407,19 @@
           fireEvent($('.whoop'), 'click');
         });
 
+        it('should not fire when navigating to a different domain', function(done){
+          page('/diff-domain', function(ctx){
+            expect(true).to.equal(false);
+          });
+
+          document.addEventListener('click', function onDocClick(ev){
+            ev.preventDefault();
+            document.removeEventListener('click', onDocClick);
+            done();
+          });
+
+          fireEvent($('.diff-domain'), 'click');
+        });
       });
 
 


### PR DESCRIPTION
This fixes #407. Previously sameOrigin() was returning false positives
due to depending on an indexOf() === 0. This uses the URL constructor
(falling back to an anchor) for better accuracy.