### PR TITLE
Change test infrastructure to run inside of iframes

### DIFF
--- a/index.js
+++ b/index.js
@@ -594,8 +594,6 @@
     if (e.metaKey || e.ctrlKey || e.shiftKey) return;
     if (e.defaultPrevented) return;
 
-
-
     // ensure link
     // use shadow dom when available
     var el = e.path ? e.path[0] : e.target;
@@ -688,9 +686,10 @@
     if(!href || !isLocation) return false;
     var url = toURL(href);
 
-    return location.protocol === url.protocol &&
-      location.hostname === url.hostname &&
-      location.port === url.port;
+    var loc = pageWindow.location;
+    return loc.protocol === url.protocol &&
+      loc.hostname === url.hostname &&
+      loc.port === url.port;
   }
 
   /**

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<title>Blank page</title>
+<body>
+  <ul class="links">
+    <li><a class="index" href="./">/</a></li>
+    <li><a class="whoop" href="#whoop">#whoop</a></li>
+    <li><a class="about" href="./about">/about</a></li>
+    <li><a class="link-trailing" href="./link-trailing/">/link-trailing/</a></li>
+    <li><a class="link-no-trailing" href="./link-no-trailing">/link-no-trailing</a></li>
+    <li><a class="contact" href="./contact">/contact</a></li>
+    <li><a class="contact-me" href="./contact/me">/contact/me</a></li>
+    <li><a class="not-found" href="./not-found?foo=bar">/not-found</a></li>
+    <li><a class="diff-domain" href="http://example.com.uk/diff/domain">another domain</a></li>
+  </ul>
+</body>

--- a/test/tests.js
+++ b/test/tests.js
@@ -42,14 +42,14 @@
   var fireEvent = function(node, eventName) {
       var event;
 
-      if(typeof window.Event === 'function') {
-        event = new window.MouseEvent(eventName, {
+      if(typeof testWindow().Event === 'function') {
+        event = new testWindow().MouseEvent(eventName, {
           bubbles: true,
           button: 1
         });
         Object.defineProperty(event, 'which', { value: null });
       } else {
-        event = document.createEvent('MouseEvents');
+        event = testWindow().document.createEvent('MouseEvents');
 
         // https://developer.mozilla.org/en-US/docs/Web/API/event.initMouseEvent
         event.initEvent(
@@ -366,7 +366,6 @@
       describe('links dispatcher', function() {
 
         it('should invoke the callback', function(done) {
-          //this.timeout(60000);
           page('/about', function() {
             done();
           });

--- a/test/tests.js
+++ b/test/tests.js
@@ -266,11 +266,22 @@
           page.back('/first');
 
         });
+
         it('should decrement page.len on back()', function() {
           var lenAtFirst = page.len;
           page('/second');
           page.back('/first');
           expect(page.len).to.be.equal(lenAtFirst);
+        });
+
+        it('calling back() when there is nothing in the history should go to the given path', function(done){
+          page('/fourth', function(){
+            expect(page.len).to.be.equal(0);
+            done();
+          });
+          page.len = 0;
+          page.back('/fourth');
+
         });
       });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -15,7 +15,7 @@
     expect = this.expect,
     page = this.page,
     baseTag,
-    htmlWrapper,
+    frame,
     $,
     jsdomSupport;
 
@@ -33,7 +33,9 @@
       expect = chai.expect;
     }
 
-    $ = document.querySelector.bind(document);
+    $ = function(sel) {
+      return frame.contentWindow.document.querySelector(sel);
+    };
 
   });
 
@@ -62,7 +64,10 @@
 
       node.dispatchEvent(event);
     },
-    beforeTests = function(options) {
+    testWindow = function(){
+      return frame.contentWindow;
+    },
+    beforeTests = function(options, done) {
       page.callbacks = [];
       page.exits = [];
       options = options || {};
@@ -71,33 +76,32 @@
         called = true;
       });
 
-      if(setbase) {
-        if (!baseTag) {
-          baseTag = document.createElement('base');
-          $('head').appendChild(baseTag);
+      function onFrameLoad(){
+        if(setbase) {
+          var baseTag = frame.contentWindow.document.createElement('base');
+          frame.contentWindow.document.head.appendChild(baseTag);
+
+          baseTag.setAttribute('href', (base ? base + '/' : '/'));
         }
 
-        baseTag.setAttribute('href', (base ? base + '/' : '/'));
+        options.window = frame.contentWindow;
+        page(options);
+        page(base ? base + '/' : '/');
+        done();
       }
 
-      htmlWrapper = document.createElement('div');
-
-      html += '<ul class="links">';
-      html += '      <li><a class="index" href="./">/</a></li>';
-      html += '      <li><a class="whoop" href="#whoop">#whoop</a></li>';
-      html += '      <li><a class="about" href="./about">/about</a></li>';
-      html += '      <li><a class="link-trailing" href="./link-trailing/">/link-trailing/</a></li>';
-      html += '      <li><a class="link-no-trailing" href="./link-no-trailing">/link-no-trailing</a></li>';
-      html += '      <li><a class="contact" href="./contact">/contact</a></li>';
-      html += '      <li><a class="contact-me" href="./contact/me">/contact/me</a></li>';
-      html += '      <li><a class="not-found" href="./not-found?foo=bar">/not-found</a></li>';
-      html += '      <li><a class="diff-domain" href="http://example.com.uk/diff/domain">another domain</a></li>';
-      html += '</ul>';
-
-      htmlWrapper.innerHTML = html;
-      document.body.appendChild(htmlWrapper);
-
-      page(options);
+      frame = document.createElement('iframe');
+      document.body.appendChild(frame);
+      if(isNode) {
+        var cntn = require('fs').readFileSync(__dirname + '/test-page.html', 'utf8');
+        cntn = cntn.replace('<!doctype html>', '').trim();
+        cntn = cntn.replace('<html lang="en">', '');
+        frame.contentWindow.document.documentElement.innerHTML = cntn;
+        onFrameLoad();
+      } else {
+        frame.src = './test-page.html';
+        frame.addEventListener('load', onFrameLoad);
+      }
     },
     replaceable = function(route) {
       function realCallback(ctx) {
@@ -251,8 +255,9 @@
         it('should move back to history', function(done) {
           first.once(function(){
             var path = hashbang
-              ? location.hash.replace('#!', '')
-              : location.pathname;
+              ? testWindow().location.hash.replace('#!', '')
+              : testWindow().location.pathname;
+            path = path.replace(base, '');
             expect(path).to.be.equal('/first');
             done();
           });
@@ -413,9 +418,9 @@
             expect(true).to.equal(false);
           });
 
-          document.addEventListener('click', function onDocClick(ev){
+          testWindow().document.addEventListener('click', function onDocClick(ev){
             ev.preventDefault();
-            document.removeEventListener('click', onDocClick);
+            testWindow().document.removeEventListener('click', onDocClick);
             done();
           });
 
@@ -513,23 +518,20 @@
       });
     },
     afterTests = function() {
-
-      document.body.removeChild(htmlWrapper);
-
       called = false;
       page.stop();
       page.base('');
       page.strict(false);
-      page('/');
+      //page('/');
       base = '';
       setbase = true;
-
+      document.body.removeChild(frame);
     };
 
   describe('Html5 history navigation', function() {
 
-    before(function() {
-      beforeTests();
+    before(function(done) {
+      beforeTests(null, done);
     });
 
     tests();
@@ -542,16 +544,17 @@
 
   describe('Hashbang option enabled', function() {
 
-    before(function() {
+    before(function(done) {
       hashbang = true;
       beforeTests({
         hashbang: hashbang
-      });
+      }, done);
     });
 
     tests();
 
     after(function() {
+      hashbang = false;
       afterTests();
     });
 
@@ -559,10 +562,10 @@
 
   describe('Different Base', function() {
 
-    before(function() {
+    before(function(done) {
       base = '/newBase';
       page.base(base);
-      beforeTests();
+      beforeTests(null, done);
     });
 
     tests();
@@ -574,11 +577,11 @@
   });
 
   describe('URL path component decoding disabled', function() {
-    before(function() {
+    before(function(done) {
       decodeURLComponents = false;
       beforeTests({
         decodeURLComponents: decodeURLComponents
-      });
+      }, done);
     });
 
     tests();
@@ -589,9 +592,9 @@
   });
 
   describe('Strict path matching enabled', function() {
-    before(function() {
+    before(function(done) {
       page.strict(true);
-      beforeTests();
+      beforeTests(null, done);
     });
 
     tests();
@@ -604,7 +607,7 @@
   var describei = jsdomSupport ? describe : describe.skip;
 
   describei('File protocol', function() {
-    before(function(){
+    before(function(done){
       jsdomSupport.setup({
         url: 'file:///var/html/index.html'
       }, Function.prototype);
@@ -613,7 +616,11 @@
       hashbang = true;
       beforeTests({
         hashbang: hashbang
-      });
+      }, done);
+    });
+
+    after(function(){
+      hashbang = false;
     });
 
     it('test', function(){

--- a/test/tests.js
+++ b/test/tests.js
@@ -43,7 +43,8 @@
       var event;
 
       if(typeof testWindow().Event === 'function') {
-        event = new testWindow().MouseEvent(eventName, {
+        var MouseEvent = testWindow().MouseEvent;
+        event = new MouseEvent(eventName, {
           bubbles: true,
           button: 1
         });


### PR DESCRIPTION
This moves individual test to all run inside of iframes. This ensures
that there is some level of isolation for tests and that you can run
them in an actual browser and not just depend on jsdom.

This fixes #442

It also provides a new way to use an alternative to the main window by
passing the `window` option when starting page.

```js
page('/about', function(){

});

page({
  window: myIframe.contentWindow
})
```

In the future (probably post-2.0) I want to make it possible to have
multiple Pages running at the same time, but for now this is what we'll
have.