### PR TITLE
Prevent hash from being part of the ctx.pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,7 +438,7 @@
     if (!hashbang) {
       if (!~this.path.indexOf('#')) return;
       var parts = this.path.split('#');
-      this.path = parts[0];
+      this.path = this.pathname = parts[0];
       this.hash = decodeURLEncodedURIComponent(parts[1]) || '';
       this.querystring = this.querystring.split('#')[0];
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -499,6 +499,15 @@
           page('/blog/post/something');
         });
 
+        it('should not include hash in ctx.pathname', function(done){
+          page('/contact', function(ctx){
+            expect(ctx.pathname).to.equal('/contact');
+            done();
+          });
+
+          page(hashbang ? '/contact' : '/contact#bang');
+        });
+
         describe('when next() is invoked', function() {
           it('should invoke subsequent matching middleware', function(done) {
 


### PR DESCRIPTION
As with the `URL()` constructor, we should leave the hash out of the
pathname. Fixes #375