### PR TITLE
Add a note about usage with a CDN

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,22 @@ page()
   $ bower install visionmedia/page.js
   ```
 
+  Or use with a CDN. We support:
+
+  * [cdnjs](https://cdnjs.com/libraries/page.js)
+  * [unpkg](https://unpkg.com/page.js/page.js)
+
+  Example usage is:
+
+  ```html
+  <script src="https://unpkg.com/page.js/page.js"></script>
+  <script>
+    page('/about', function(){
+      // Do stuff
+    });
+  </script>
+  ```
+
 ## Running examples
 
   To run examples do the following to install dev dependencies and run the example server:


### PR DESCRIPTION
This adds a note about using page.js through a CDN, and the two CDNs we
support (unpkg and cdnjs).

Closes #120