### PR TITLE
Ensure we are on the same page when exiting for hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -628,7 +628,7 @@
 
     // ensure non-hash for the same path
     var link = el.getAttribute('href');
-    if (!hashbang && isLocation && el.pathname === location.pathname && (el.hash || '#' === link)) return;
+    if(!hashbang && samePath(el) && (el.hash || '#' === link)) return;
 
     // Check for mailto: in the href
     if (link && link.indexOf('mailto:') > -1) return;
@@ -704,6 +704,13 @@
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
       loc.port === url.port;
+  }
+
+  function samePath(url) {
+    if(!isLocation) return false;
+    var loc = pageWindow.location;
+    return url.pathname === loc.pathname &&
+      url.search === loc.search;
   }
 
   /**

--- a/test/test-page.html
+++ b/test/test-page.html
@@ -6,6 +6,8 @@
     <li><a class="index" href="./">/</a></li>
     <li><a class="whoop" href="#whoop">#whoop</a></li>
     <li><a class="about" href="./about">/about</a></li>
+    <li><a class="query" href="./query?foo=bar">/query?foo=bar</a></li>
+    <li><a class="query-hash" href="./query#page">/query#page</a></li>
     <li><a class="link-trailing" href="./link-trailing/">/link-trailing/</a></li>
     <li><a class="link-no-trailing" href="./link-no-trailing">/link-no-trailing</a></li>
     <li><a class="contact" href="./contact">/contact</a></li>

--- a/test/tests.js
+++ b/test/tests.js
@@ -388,7 +388,6 @@
       });
 
       describe('links dispatcher', function() {
-
         it('should invoke the callback', function(done) {
           page('/about', function() {
             done();
@@ -568,6 +567,19 @@
     });
 
     tests();
+
+    it('Should dispatch when going to a hash on same path', function(done){
+      var cnt = 0;
+      page('/query', function(){
+        cnt++;
+        if(cnt === 2) {
+          done();
+        }
+      });
+
+      fireEvent($('.query'), 'click');
+      fireEvent($('.query-hash'), 'click');
+    });
 
     after(function() {
       afterTests();


### PR DESCRIPTION
The onclick listening tries not to do anything when navigating to a hash
within the same page. However previously it did not take the `search`
into consideration so when you were on a page with a query param and
then navigating to the same path, without a query param, but with a
hash, it would cause a page navigation.

Fix is to include the search in this algorithm. Fixes #289