### PR TITLE
Added a check for window existence before accessing location property.

### DIFF
--- a/page.js
+++ b/page.js
@@ -710,8 +710,8 @@
    */
   function getBase() {
     if(!!base) return base;
-    var loc = pageWindow.location;
-    return (hashbang && loc.protocol === 'file:') ? loc.pathname : base;
+    var loc = hasWindow && pageWindow.location;
+    return (hasWindow && hashbang && loc.protocol === 'file:') ? loc.pathname : base;
   }
 
   page.sameOrigin = sameOrigin;


### PR DESCRIPTION
This change was introduced in #443. In some environments where `window` is not available it causes an attempt to access a property of `window.location`, which leads to an error.