### PR TITLE
Added a check for window existence before accessing location property.

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,8 +721,8 @@
    */
   function getBase() {
     if(!!base) return base;
-    var loc = pageWindow.location;
-    return (hashbang && loc.protocol === 'file:') ? loc.pathname : base;
+    var loc = hasWindow && pageWindow.location;
+    return (hasWindow && hashbang && loc.protocol === 'file:') ? loc.pathname : base;
   }
 
   page.sameOrigin = sameOrigin;


### PR DESCRIPTION
This change was introduced in #443. In some environments where window is not available it causes an attempt to access a property of window.location, which leads to an error.

This is a repeat of #455 because I edited the wrong file previously.