### PR TITLE
Properly checking the object before pointing to an attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -721,8 +721,8 @@
    */
   function getBase() {
     if(!!base) return base;
-    var loc = hasWindow && pageWindow.location;
-    return (hasWindow && hashbang && loc.protocol === 'file:') ? loc.pathname : base;
+    var loc = hasWindow && pageWindow && pageWindow.location;
+    return (hasWindow && hashbang && loc && loc.protocol === 'file:') ? loc.pathname : base;
   }
 
   page.sameOrigin = sameOrigin;


### PR DESCRIPTION
I have noticed in some cases the `getBase` function is throwing an error because `pageWindow` is not properly checked.

So this PR is addressing this issue to resolve `Cannot read property 'location' of undefined` error.

It would be great if someone can do more investigation of why in some cases `pageWindow` become undefined in the first place.