### PR TITLE
Use event.composedPath as a fallback in onclick handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -611,8 +611,8 @@
     if (e.defaultPrevented) return;
 
     // ensure link
-    // use shadow dom when available
-    var el = e.path ? e.path[0] : e.target;
+    // use shadow dom when available if not, fall back to composedPath() for browsers that only have shady
+    var el = e.path ? e.path[0] : (e.composedPath ? e.composedPath()[0] : e.target);
 
     // continue ensure link
     // el.nodeName for svg links are 'a' instead of 'A'


### PR DESCRIPTION
Before falling back to e.target from e.path use e.composedPath. This
allows the onclick handler to work for browsers using ShadyDom AND
Polymer 2.

IF I  use Polymer 2 and Page.js in FF or Safari then e.path doesn't exist because there is no ShadowDOM. e.target is the Top-most shadow DOM and is therefore not helpful.