### PR TITLE
Fix - IE11 anchor handling not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -715,8 +715,7 @@
 
     var loc = pageWindow.location;
     return loc.protocol === url.protocol &&
-      loc.hostname === url.hostname &&
-      loc.port === url.port;
+      loc.host === url.host;
   }
 
   function samePath(url) {

--- a/page.js
+++ b/page.js
@@ -1115,8 +1115,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
 
     var loc = pageWindow.location;
     return loc.protocol === url.protocol &&
-      loc.hostname === url.hostname &&
-      loc.port === url.port;
+      loc.host === url.host;
   }
 
   function samePath(url) {


### PR DESCRIPTION
Once IE11 don't support `URL.hostname`, we can use `URL.host` to check "sameOrigin" on an anchor... See how `URL` behaves in both environments

```javascript

const url = new URL("http://10.20.0.57:7000/")

console.log(url.hostname) //Chrome - 10.20.0.57
console.log(url.hostname) //IE11 - undefined

console.log(url.host) //Chrome - 10.20.0.57:7000
console.log(url.host) //IE11 - 10.20.0.57:7000
```