### PR TITLE
Implement dispatching iteratively.

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,7 +368,9 @@
         nextCalled = true;
       };
 
-      for (var i = 0; i < page.callbacks.length; i++) {
+      var i = 0;
+
+      do {
         var fn = page.callbacks[i];
         nextCalled = false;
 
@@ -383,7 +385,7 @@
         if (!nextCalled) {
           return;
         }
-      }
+      } while(i++ < page.callbacks.length);
     }
 
     if (prev) {

--- a/index.js
+++ b/index.js
@@ -342,33 +342,47 @@
    */
 
   page.dispatch = function(ctx, prev) {
-    function nextExit() {
+    function nextExit(initValue) {
       var nextCalled;
-      var nextCallback = function() {
+      var processRecursively = false;
+
+      var callbackWrapper = function() {
         nextCalled = true;
+        if (processRecursively) {
+          return nextExit(j + 1);
+        }
       };
 
-      var j = 0;
+      var j = initValue !== undefined ? initValue : 0;
 
       do {
         nextCalled = false;
         var fn = page.exits[j];
         if (!fn) return nextEnter();
-        fn(prev, nextCallback);
 
+        fn(prev, callbackWrapper);
+        // No callback yet, which means the callback is asynchronous.
+        // Toggle flag so that the callback wrapper handles the rest.
         if (!nextCalled) {
+          processRecursively = true;
           return;
         }
+
       } while(j++ < page.exits.length);
     }
 
-    function nextEnter() {
+    function nextEnter(initValue) {
       var nextCalled;
-      var nextCallback = function() {
+      var processRecursively = false;
+
+      var callbackWrapper = function() {
         nextCalled = true;
+        if (processRecursively) {
+          return nextEnter(i + 1);
+        }
       };
 
-      var i = 0;
+      var i = initValue !== undefined ? initValue : 0;
 
       do {
         var fn = page.callbacks[i];
@@ -380,9 +394,11 @@
         }
         if (!fn) return unhandled(ctx);
 
-        fn(ctx, nextCallback);
-
+        fn(ctx, callbackWrapper);
+        // No callback yet, which means the callback is asynchronous.
+        // Toggle flag so that the callback wrapper handles the rest.
         if (!nextCalled) {
+          processRecursively = true;
           return;
         }
       } while(i++ < page.callbacks.length);

--- a/page.js
+++ b/page.js
@@ -768,7 +768,9 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
         nextCalled = true;
       };
 
-      for (var i = 0; i < page.callbacks.length; i++) {
+      var i = 0;
+
+      do {
         var fn = page.callbacks[i];
         nextCalled = false;
 
@@ -783,7 +785,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
         if (!nextCalled) {
           return;
         }
-      }
+      } while(i++ < page.callbacks.length);
     }
 
     if (prev) {

--- a/page.js
+++ b/page.js
@@ -742,24 +742,48 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    */
 
   page.dispatch = function(ctx, prev) {
-    var i = 0,
-      j = 0;
-
     function nextExit() {
-      var fn = page.exits[j++];
-      if (!fn) return nextEnter();
-      fn(prev, nextExit);
+      var nextCalled;
+      var nextCallback = function() {
+        nextCalled = true;
+      };
+
+      var j = 0;
+
+      do {
+        nextCalled = false;
+        var fn = page.exits[j];
+        if (!fn) return nextEnter();
+        fn(prev, nextCallback);
+
+        if (!nextCalled) {
+          return;
+        }
+      } while(j++ < page.exits.length);
     }
 
     function nextEnter() {
-      var fn = page.callbacks[i++];
+      var nextCalled;
+      var nextCallback = function() {
+        nextCalled = true;
+      };
 
-      if (ctx.path !== page.current) {
-        ctx.handled = false;
-        return;
+      for (var i = 0; i < page.callbacks.length; i++) {
+        var fn = page.callbacks[i];
+        nextCalled = false;
+
+        if (ctx.path !== page.current) {
+          ctx.handled = false;
+          return;
+        }
+        if (!fn) return unhandled(ctx);
+
+        fn(ctx, nextCallback);
+
+        if (!nextCalled) {
+          return;
+        }
       }
-      if (!fn) return unhandled(ctx);
-      fn(ctx, nextEnter);
     }
 
     if (prev) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -133,6 +133,19 @@
         it('should invoke the matching callback', function() {
           expect(called).to.equal(true);
         });
+
+        it('should invoke the matching async callbacks', function(done) {
+          page('/async', function(ctx, next) {
+            setTimeout(function() {
+              next();
+            }, 10);
+          }, function(ctx, next) {
+            setTimeout(function() {
+              done();
+            }, 10);
+          });
+          page('/async');
+        });
       });
 
       describe('on redirect', function() {
@@ -174,6 +187,27 @@
           });
 
           page('/exit');
+          page('/');
+        });
+
+        it('should run async callbacks when exiting the page', function(done) {
+          var visited = false;
+          page('/async-exit', function() {
+            visited = true;
+          });
+
+          page.exit('/async-exit', function(ctx, next) {
+            setTimeout(function() {
+              next();
+            }, 10);
+          }, function(ctx, next) {
+            setTimeout(function () {
+              expect(visited).to.equal(true);
+              done();
+            }, 10);
+          });
+
+          page('/async-exit');
           page('/');
         });
 


### PR DESCRIPTION
Hello, `page.js` maintainers! 👋 

In applications with a large number of middlewares, the recursive implementation of `nextEnter` and `nextExit` become a problem, by generating deep call stacks (2x the number of middlewares, as far
as I can tell).

Even where the call stack size isn't directly an issue, the added cruft to the call tree can make debugging and profiling harder.

Recursive (note the many layers of `nextEnter`):

![image](https://user-images.githubusercontent.com/409615/42725650-2aff0288-877f-11e8-82d8-d2fe8c92a056.png)

Iterative (note how there's a single layer of `nextEnter` now):

![image](https://user-images.githubusercontent.com/409615/42725656-397127e2-877f-11e8-996e-834eba0f7353.png)

There doesn't seem to be a strong reason for these methods to be implemented recursively, so I reimplemented them iteratively.

All the tests work correctly, but please double-check the logic, and let me know if there's anything wrong with it, the coding style, or my commit in general.

Thanks for taking a look! 🙂 