### PR TITLE
add routerId to config options: support multiple instances of page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -149,6 +149,7 @@ page('/default');
   - `dispatch` perform initial dispatch [__true__]
   - `hashbang` add `#!` before urls [__false__]
   - `decodeURLComponents` remove URL encoding from path components (query string, pathname, hash) [__true__]
+  - `routerId` an identifier for the page instance (should be unique between instances of page living under the same domain) [__PAGE_ROUTER__]
 
   If you wish to load serve initial content
   from the server you likely will want to

--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@
    *    - `click` bind to click events [true]
    *    - `popstate` bind to popstate [true]
    *    - `dispatch` perform initial dispatch [true]
+   *    - `routerId` an identifier for the page instance ['PAGE_ROUTER']
    *
    * @param {Object} options
    * @api public
@@ -192,6 +193,7 @@
     options = options || {};
     if (running) return;
     running = true;
+    page.id = options.routerId || 'PAGE_ROUTER';
     pageWindow = options.window || (hasWindow && window);
     if (false === options.dispatch) dispatch = false;
     if (false === options.decodeURLComponents) decodeURLComponents = false;
@@ -444,6 +446,7 @@
     this.title = (hasDocument && pageWindow.document.title);
     this.state = state || {};
     this.state.path = path;
+    this.state.router = page.id;
     this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
     this.pathname = decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);
     this.params = {};
@@ -592,7 +595,11 @@
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;
-        page.replace(path, e.state);
+        if (e.state.router === page.id) {
+          page.replace(path, e.state);
+        } else {
+          pageWindow.location = path;
+        }
       } else if (isLocation) {
         var loc = pageWindow.location;
         page.show(loc.pathname + loc.hash, undefined, undefined, false);

--- a/page.js
+++ b/page.js
@@ -583,6 +583,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    *    - `click` bind to click events [true]
    *    - `popstate` bind to popstate [true]
    *    - `dispatch` perform initial dispatch [true]
+   *    - `routerId` an identifier for the page instance ['PAGE_ROUTER']
    *
    * @param {Object} options
    * @api public
@@ -592,6 +593,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     options = options || {};
     if (running) return;
     running = true;
+    page.id = options.routerId || 'PAGE_ROUTER';
     pageWindow = options.window || (hasWindow && window);
     if (false === options.dispatch) dispatch = false;
     if (false === options.decodeURLComponents) decodeURLComponents = false;
@@ -844,6 +846,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this.title = (hasDocument && pageWindow.document.title);
     this.state = state || {};
     this.state.path = path;
+    this.state.router = page.id;
     this.querystring = ~i ? decodeURLEncodedURIComponent(path.slice(i + 1)) : '';
     this.pathname = decodeURLEncodedURIComponent(~i ? path.slice(0, i) : path);
     this.params = {};
@@ -992,7 +995,11 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       if (!loaded) return;
       if (e.state) {
         var path = e.state.path;
-        page.replace(path, e.state);
+        if (e.state.router === page.id) {
+          page.replace(path, e.state);
+        } else {
+          pageWindow.location = path;
+        }
       } else if (isLocation) {
         var loc = pageWindow.location;
         page.show(loc.pathname + loc.hash, undefined, undefined, false);

--- a/test/tests.js
+++ b/test/tests.js
@@ -329,6 +329,19 @@
           page.len = 0;
           page.back();
         });
+        
+        it('calling back() from a different app should make the page reload', function(done){
+          var loc = window.location.href;
+          var id  = page.id;
+          page('/another-app/route', function(ctx){
+            expect(loc).to.not.eql(ctx.path);
+            expect(ctx.state.router).to.not.eql(id);
+            done();
+          });
+          page.len = 0;
+          page.id = 'ANOTHER_PAGE_ROUTER';
+          page.back('/another-app/route');
+        });
       });
 
       describe('ctx.querystring', function() {


### PR DESCRIPTION
When an application has multiple heroku apps mounted under the same domain and each app uses PageJS as its client-side router, the browser back/forward buttons don't work between the seperate apps. This is because the popstate event handler of each instance assumes that it is the only entity modifing the history state, and therefore tries to route paths that it may not own.

For this reason, I added the option for a routerId to disinguish between multiple apps (that each use a different instance of page). Each instance now includes its id in the history state, and that id is used by page to know whether to route on the client's side, or defer to the server.