### PR TITLE
make sure _onpopstate is defined in non-browser environments

### DIFF
--- a/page.js
+++ b/page.js
@@ -829,7 +829,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return;
+      return function() {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;


### PR DESCRIPTION
fixes #501 

Apparently the internal `_onpopstate` method isn't defined in environments where the `window` object doesn't exist such as test runners or Node.js. This PR adds a simple noop method to make sure it's defined.

I'm not aware of the internals of page.js and not sure if it causes any other side effects. I'm happy for feedback if this is actually a helpful fix.