### PR TITLE
Update named wildcard

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -467,7 +467,7 @@ page('/user/*', loadUser)
   would provide "/javascripts/jquery.js" as `ctx.params.file`:
 
 ```js
-page('/file/:file(*)', loadUser)
+page('/file/:file(.*)', loadUser)
 ```
 
   And of course `RegExp` literals, where the capture


### PR DESCRIPTION
Using only `(*)` gives a regexp error of: "Nothing to repeat". You have to use `(.*)` for it to work. This happens on latest version, 1.10.1.