### PR TITLE
[WIP] Prevent duplicated event bindings for page instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
    * The page instance
    * @api private
    */
-  function Page() {
+  function Page(options) {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -51,6 +51,8 @@
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
+
+    this.configure(options);
   }
 
   /**
@@ -69,25 +71,6 @@
     this._popstate = opts.popstate !== false && hasWindow;
     this._click = opts.click !== false && hasDocument;
     this._hashbang = !!opts.hashbang;
-
-    var _window = this._window;
-    if(this._popstate) {
-      _window.addEventListener('popstate', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('popstate', this._onpopstate, false);
-    }
-
-    if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
-    } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
-    }
-
-    if(this._hashbang && hasWindow && !hasHistory) {
-      _window.addEventListener('hashchange', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('hashchange', this._onpopstate, false);
-    }
   };
 
   /**
@@ -143,6 +126,25 @@
 
   Page.prototype.start = function(options) {
     this.configure(options);
+
+    var _window = this._window;
+    if(this._popstate) {
+      _window.addEventListener('popstate', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('popstate', this._onpopstate, false);
+    }
+
+    if (this._click) {
+      _window.document.addEventListener(clickEvent, this._onclick, false);
+    } else if(hasDocument) {
+      _window.document.removeEventListener(clickEvent, this._onclick, false);
+    }
+
+    if(this._hashbang && hasWindow && !hasHistory) {
+      _window.addEventListener('hashchange', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('hashchange', this._onpopstate, false);
+    }
 
     if (!this._dispatch) return;
     this._running = true;
@@ -427,7 +429,7 @@
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return function () {};
+      return function() {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -519,8 +521,8 @@
   /**
    * Create a new `page` instance and function
    */
-  function createPage() {
-    var pageInstance = new Page();
+  function createPage(options) {
+    var pageInstance = new Page(options);
 
     function pageFn(/* args */) {
       return page.apply(pageInstance, arguments);

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -51,8 +51,6 @@
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -429,7 +427,7 @@
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return;
+      return function () {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -521,7 +519,7 @@
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {

--- a/page.js
+++ b/page.js
@@ -433,7 +433,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page() {
+  function Page(options) {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -451,6 +451,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
+
+    this.configure(options);
   }
 
   /**
@@ -469,25 +471,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._popstate = opts.popstate !== false && hasWindow;
     this._click = opts.click !== false && hasDocument;
     this._hashbang = !!opts.hashbang;
-
-    var _window = this._window;
-    if(this._popstate) {
-      _window.addEventListener('popstate', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('popstate', this._onpopstate, false);
-    }
-
-    if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
-    } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
-    }
-
-    if(this._hashbang && hasWindow && !hasHistory) {
-      _window.addEventListener('hashchange', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('hashchange', this._onpopstate, false);
-    }
   };
 
   /**
@@ -543,6 +526,25 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
 
   Page.prototype.start = function(options) {
     this.configure(options);
+
+    var _window = this._window;
+    if(this._popstate) {
+      _window.addEventListener('popstate', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('popstate', this._onpopstate, false);
+    }
+
+    if (this._click) {
+      _window.document.addEventListener(clickEvent, this._onclick, false);
+    } else if(hasDocument) {
+      _window.document.removeEventListener(clickEvent, this._onclick, false);
+    }
+
+    if(this._hashbang && hasWindow && !hasHistory) {
+      _window.addEventListener('hashchange', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('hashchange', this._onpopstate, false);
+    }
 
     if (!this._dispatch) return;
     this._running = true;
@@ -827,7 +829,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return function () {};
+      return function() {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -919,8 +921,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage() {
-    var pageInstance = new Page();
+  function createPage(options) {
+    var pageInstance = new Page(options);
 
     function pageFn(/* args */) {
       return page.apply(pageInstance, arguments);

--- a/page.js
+++ b/page.js
@@ -433,7 +433,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -451,8 +451,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -829,7 +827,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return function() {};
+      return function () {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -921,7 +919,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {

--- a/page.mjs
+++ b/page.mjs
@@ -400,7 +400,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * Module dependencies.
    */
 
-
+  
 
   /**
    * Short-cuts for global-object checks
@@ -427,7 +427,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -445,8 +445,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -823,7 +821,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return;
+      return function () {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -915,7 +913,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {

--- a/page.mjs
+++ b/page.mjs
@@ -427,7 +427,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page() {
+  function Page(options) {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -445,6 +445,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this._onclick = this._onclick.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
+
+    this.configure(options);
   }
 
   /**
@@ -463,25 +465,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._popstate = opts.popstate !== false && hasWindow;
     this._click = opts.click !== false && hasDocument;
     this._hashbang = !!opts.hashbang;
-
-    var _window = this._window;
-    if(this._popstate) {
-      _window.addEventListener('popstate', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('popstate', this._onpopstate, false);
-    }
-
-    if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
-    } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
-    }
-
-    if(this._hashbang && hasWindow && !hasHistory) {
-      _window.addEventListener('hashchange', this._onpopstate, false);
-    } else if(hasWindow) {
-      _window.removeEventListener('hashchange', this._onpopstate, false);
-    }
   };
 
   /**
@@ -537,6 +520,25 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
 
   Page.prototype.start = function(options) {
     this.configure(options);
+
+    var _window = this._window;
+    if(this._popstate) {
+      _window.addEventListener('popstate', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('popstate', this._onpopstate, false);
+    }
+
+    if (this._click) {
+      _window.document.addEventListener(clickEvent, this._onclick, false);
+    } else if(hasDocument) {
+      _window.document.removeEventListener(clickEvent, this._onclick, false);
+    }
+
+    if(this._hashbang && hasWindow && !hasHistory) {
+      _window.addEventListener('hashchange', this._onpopstate, false);
+    } else if(hasWindow) {
+      _window.removeEventListener('hashchange', this._onpopstate, false);
+    }
 
     if (!this._dispatch) return;
     this._running = true;
@@ -821,7 +823,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Page.prototype._onpopstate = (function () {
     var loaded = false;
     if ( ! hasWindow ) {
-      return function () {};
+      return function() {};
     }
     if (hasDocument && document.readyState === 'complete') {
       loaded = true;
@@ -913,8 +915,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage() {
-    var pageInstance = new Page();
+  function createPage(options) {
+    var pageInstance = new Page(options);
 
     function pageFn(/* args */) {
       return page.apply(pageInstance, arguments);


### PR DESCRIPTION
Fixes #508 

I've removed the `this.configure()` call from the `Page` constructor (and the `options` argument) since it's already called and used at `page.start`.

(Maybe just passing the `options` throught the `.create()` would be enough, but it wouldn't solve the duped events in case of the `.start` being also called at some point)