### PR TITLE
Export onclick handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -543,6 +543,7 @@
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn._onclick = pageInstance._onclick.bind(pageInstance);
 
     pageFn.create = createPage;
 

--- a/page.js
+++ b/page.js
@@ -943,6 +943,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn._onclick = pageInstance._onclick.bind(pageInstance);
 
     pageFn.create = createPage;
 

--- a/page.mjs
+++ b/page.mjs
@@ -937,6 +937,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn._onclick = pageInstance._onclick.bind(pageInstance);
 
     pageFn.create = createPage;
 


### PR DESCRIPTION
Rationale: We're using `page.js` for client-side routing in a large React-based project. While removing one instance of a React element that for legacy reasons had been accidentally rendered twice, we've noticed that after removing it, React's synthetic event handling collides with `page.js`'s `click` binding: On a given `<a />` element with both `href` and `onclick` attributes, `page.js` would attach its `click` handler to it, loading the route specified at `href` _before_ the app-provided `onclick` handler would be invoked. Our app-provided [`onclick` handler](https://github.com/Automattic/wp-calypso/blob/2cf1ffdb1e8c42d8a92b2c80a20202dbf8ca81e7/client/layout/masterbar/publish.jsx#L53-L60) contains a (conditional) `event.preventDefault()`, so the expected behavior would be that (if the relevant condition evaluates to `true`) to only run the code in the `onclick` handler, and not to direct to the `href`-specified route. (I've also tried `event.stopPropagation()`.)

We've found that we can work around this issue by setting `click: false` on `page.start()`, exporting `page.js`'s `onclick` handler, and attaching it to our top-level React element, see https://github.com/Automattic/wp-calypso/pull/26944.

This PR is about the exporting part -- would this be an acceptable addition to `page.js`? We haven't been able to find a better solution to this problem that doesn't require modifications to `page.js`, but are obviously grateful for any sort of feedback or advice.