### PR TITLE
Made the sameOrigin call work consistently in IE11.

### DIFF
--- a/page.js
+++ b/page.js
@@ -888,7 +888,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     var url = this._toURL(href);
     var window = this._window;
 
-    var loc = window.location;
+    var loc = this._toURL(window.location);
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
       loc.port === url.port;


### PR DESCRIPTION
I found that in Internet Explorer 11 (this is for a corporate client still on Windows 7), when the host name does not include the port number, (e.g. http://internal.test.com/), then the anchor tag returned by `_toURL()` call had a different port number ("80") to the port number from `window.location` (""). As such, the `sameOrigin()` call was returning false, resulting in routing not being captured.

This was occurring in both http and https sites that did not explicitly include the port number in the url.

I tested this fix in Chrome and Firefox on Windows and it still works there.