### PR TITLE
Export and document clickHandler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -218,6 +218,10 @@ var otherPage = page.create({ window: iframe.contentWindow });
 otherPage('/', main);
 ```
 
+### page.clickHandler
+
+This is the click handler used by page to handle routing when a user clicks an anchor like `<a href="/user/profile">`. This is exported for those who want to disable the click handling behavior with `page.start({ click: false })`, but still might want to dispatch based on the click handler's logic in some scenarios.
+
 ### Context
 
   Routes are passed `Context` objects, these may

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@
     this._hashbang = false;
 
     // bound functions
-    this._onclick = this._onclick.bind(this);
+    this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
 
     this.configure(options);
@@ -80,9 +80,9 @@
     }
 
     if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
+      _window.document.addEventListener(clickEvent, this.clickHandler, false);
     } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
+      _window.document.removeEventListener(clickEvent, this.clickHandler, false);
     }
 
     if(this._hashbang && hasWindow && !hasHistory) {
@@ -185,7 +185,7 @@
     this._running = false;
 
     var window = this._window;
-    hasDocument && window.document.removeEventListener(clickEvent, this._onclick, false);
+    hasDocument && window.document.removeEventListener(clickEvent, this.clickHandler, false);
     hasWindow && window.removeEventListener('popstate', this._onpopstate, false);
     hasWindow && window.removeEventListener('hashchange', this._onpopstate, false);
   };
@@ -346,7 +346,7 @@
    */
 
   /* jshint +W054 */
-  Page.prototype._onclick = function(e) {
+  Page.prototype.clickHandler = function(e) {
     if (1 !== this._which(e)) return;
 
     if (e.metaKey || e.ctrlKey || e.shiftKey) return;
@@ -551,6 +551,7 @@
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn.clickHandler = pageInstance.clickHandler.bind(pageInstance);
 
     pageFn.create = createPage;
 

--- a/page.js
+++ b/page.js
@@ -449,7 +449,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._hashbang = false;
 
     // bound functions
-    this._onclick = this._onclick.bind(this);
+    this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
 
     this.configure(options);
@@ -480,9 +480,9 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     }
 
     if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
+      _window.document.addEventListener(clickEvent, this.clickHandler, false);
     } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
+      _window.document.removeEventListener(clickEvent, this.clickHandler, false);
     }
 
     if(this._hashbang && hasWindow && !hasHistory) {
@@ -585,7 +585,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._running = false;
 
     var window = this._window;
-    hasDocument && window.document.removeEventListener(clickEvent, this._onclick, false);
+    hasDocument && window.document.removeEventListener(clickEvent, this.clickHandler, false);
     hasWindow && window.removeEventListener('popstate', this._onpopstate, false);
     hasWindow && window.removeEventListener('hashchange', this._onpopstate, false);
   };
@@ -746,7 +746,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    */
 
   /* jshint +W054 */
-  Page.prototype._onclick = function(e) {
+  Page.prototype.clickHandler = function(e) {
     if (1 !== this._which(e)) return;
 
     if (e.metaKey || e.ctrlKey || e.shiftKey) return;
@@ -951,6 +951,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn.clickHandler = pageInstance.clickHandler.bind(pageInstance);
 
     pageFn.create = createPage;
 

--- a/page.mjs
+++ b/page.mjs
@@ -443,7 +443,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._hashbang = false;
 
     // bound functions
-    this._onclick = this._onclick.bind(this);
+    this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
 
     this.configure(options);
@@ -474,9 +474,9 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     }
 
     if (this._click) {
-      _window.document.addEventListener(clickEvent, this._onclick, false);
+      _window.document.addEventListener(clickEvent, this.clickHandler, false);
     } else if(hasDocument) {
-      _window.document.removeEventListener(clickEvent, this._onclick, false);
+      _window.document.removeEventListener(clickEvent, this.clickHandler, false);
     }
 
     if(this._hashbang && hasWindow && !hasHistory) {
@@ -579,7 +579,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     this._running = false;
 
     var window = this._window;
-    hasDocument && window.document.removeEventListener(clickEvent, this._onclick, false);
+    hasDocument && window.document.removeEventListener(clickEvent, this.clickHandler, false);
     hasWindow && window.removeEventListener('popstate', this._onpopstate, false);
     hasWindow && window.removeEventListener('hashchange', this._onpopstate, false);
   };
@@ -740,7 +740,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    */
 
   /* jshint +W054 */
-  Page.prototype._onclick = function(e) {
+  Page.prototype.clickHandler = function(e) {
     if (1 !== this._which(e)) return;
 
     if (e.metaKey || e.ctrlKey || e.shiftKey) return;
@@ -945,6 +945,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     pageFn.exit = pageInstance.exit.bind(pageInstance);
     pageFn.configure = pageInstance.configure.bind(pageInstance);
     pageFn.sameOrigin = pageInstance.sameOrigin.bind(pageInstance);
+    pageFn.clickHandler = pageInstance.clickHandler.bind(pageInstance);
 
     pageFn.create = createPage;
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -735,6 +735,12 @@
     });
   });
 
+  describe('.clickHandler', function() {
+    it('is exported by the global page', function() {
+      expect(typeof page.clickHandler).to.equal('function');
+    });
+  });
+
   var describei = jsdomSupport ? describe : describe.skip;
 
   describei('File protocol', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -741,6 +741,22 @@
     });
   });
 
+  describe('Environments without the URL constructor', function() {
+    var URLC;
+    before(function(done) {
+      URLC = global.URL;
+      global.URL = undefined;
+      beforeTests(null, done);
+    });
+
+    tests();
+
+    after(function() {
+      global.URL = URLC;
+      afterTests();
+    });
+  });
+
   var describei = jsdomSupport ? describe : describe.skip;
 
   describei('File protocol', function() {


### PR DESCRIPTION
This adds `page.clickHandler`, which is the click handling function.
This is useful if you don't want page to handle all anchor links, but in
some scenarios you want to use its logic to dispatch events.

Closes #511