### PR TITLE
page.stop should unregister clickHandler only if page.start previously registered it

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@
     this._running = false;
 
     var window = this._window;
-    hasDocument && window.document.removeEventListener(clickEvent, this.clickHandler, false);
+    this._click && window.document.removeEventListener(clickEvent, this.clickHandler, false);
     hasWindow && window.removeEventListener('popstate', this._onpopstate, false);
     hasWindow && window.removeEventListener('hashchange', this._onpopstate, false);
   };


### PR DESCRIPTION
If the app code registered it itself or not at all, then page.stop shouldn't try to unregister it.

Sort of depends on #508 being fixed, as currently the `clickHandler` is always registered at least once, even if the app never asked for it.