### PR TITLE
Prevent duplicate event handler registration by configuring the router only once

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -51,8 +51,6 @@
     // bound functions
     this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -528,7 +526,7 @@
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {

--- a/page.js
+++ b/page.js
@@ -433,7 +433,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -451,8 +451,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -928,7 +926,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {

--- a/page.mjs
+++ b/page.mjs
@@ -427,7 +427,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * The page instance
    * @api private
    */
-  function Page(options) {
+  function Page() {
     // public things
     this.callbacks = [];
     this.exits = [];
@@ -445,8 +445,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     // bound functions
     this.clickHandler = this.clickHandler.bind(this);
     this._onpopstate = this._onpopstate.bind(this);
-
-    this.configure(options);
   }
 
   /**
@@ -922,7 +920,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   /**
    * Create a new `page` instance and function
    */
-  function createPage(options) {
+  function createPage() {
     var pageInstance = new Page();
 
     function pageFn(/* args */) {


### PR DESCRIPTION
Remove the `options` parameter from `page.create`/`createPage` (it wasn't used anyway) and also from the `Page` constructor together with the `configure` call there.

That ensures that the router is configured only once, with the user-supplied `options`, instead of being configured twice: first with default `options` in constructor, second time with user-supplied `options` in `page.start`.

Fixes a real-world issue where passing `{ click: false }` to `page.start` didn't prevent adding the global click handler to the document anyway, because the default value of the `click` option is `true`.

**How I tested this:**
Unit tests still pass both in Node and in browser.

I also tested the router in WordPress.com Calypso and it works as expected. The issues described in 
- https://github.com/visionmedia/page.js/pull/509#issuecomment-433972197
- https://github.com/Automattic/wp-calypso/pull/28071#issuecomment-433019802
- https://github.com/Automattic/wp-calypso/pull/26944

are no longer present and everything works as expected again 👌 

Based on earlier PR by @kaisermann (#509)
Fixes #508 