### PR TITLE
fix #526

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,6 +642,16 @@
   }
 
   /**
+   * Escapes RegExp characters in the given string.
+   *
+   * @param {string} s
+   * @api private
+   */
+  function escapeRegExp(s) {
+    return s.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+  }
+
+  /**
    * Initialize a new "request" `Context`
    * with the given `path` and optional initial `state`.
    *
@@ -661,7 +671,8 @@
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
-    this.path = path.replace(pageBase, '') || '/';
+    var re = new RegExp('^' + escapeRegExp(pageBase));
+    this.path = path.replace(re, '') || '/';
     if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
     this.title = (hasDocument && window.document.title);

--- a/page.js
+++ b/page.js
@@ -1042,6 +1042,16 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   }
 
   /**
+   * Escapes RegExp characters in the given string.
+   *
+   * @param {string} s
+   * @api private
+   */
+  function escapeRegExp(s) {
+    return s.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+  }
+
+  /**
    * Initialize a new "request" `Context`
    * with the given `path` and optional initial `state`.
    *
@@ -1061,7 +1071,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     var i = path.indexOf('?');
 
     this.canonicalPath = path;
-    this.path = path.replace(pageBase, '') || '/';
+    var re = new RegExp('^' + escapeRegExp(pageBase));
+    this.path = path.replace(re, '') || '/';
     if (hashbang) this.path = this.path.replace('#!', '') || '/';
 
     this.title = (hasDocument && window.document.title);


### PR DESCRIPTION
- Updated **`Context` constructor**
- Added **`escapeRegExp`**() function
_(I could use [`escapeString()` function](https://github.com/pillarjs/path-to-regexp/blob/master/index.js#L207) from `path-to-regexp` dependency but it's not publicly exposed.)_

Fixes #526 