### PR TITLE
Using replaceState with file:// protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -708,7 +708,7 @@
 
   Context.prototype.save = function() {
     var page = this.page;
-    if (hasHistory && page._window.location.protocol !== 'file:') {
+    if (hasHistory) {
         page._window.history.replaceState(this.state, this.title,
           page._hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
     }


### PR DESCRIPTION
Seems there are no any reasons not to use `replaceState` with `file://` protocol