### PR TITLE
Fix IE11 breakage with URL building for same-origin comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,7 +476,17 @@
     } else if (hasDocument) {
       var anc = window.document.createElement('a');
       anc.href = href;
-      return anc;
+      var fakeUrl = {
+        protocol: anc.protocol,
+        hostname: anc.hostname,
+        port: anc.port
+      };
+      if ((anc.protocol === 'http:' && anc.port === '80') || 
+          (anc.protocol === 'https:' && anc.port === '443')) {
+        // older IE sets the port even if it was not specified
+        fakeUrl.port = '';
+      }
+      return fakeUrl;
     }
   };
 


### PR DESCRIPTION
Page navigation in IE11 always fails the same-origin check on domains that lack ports. This is because the fallback for toURL that uses an anchor fills in the port even when it's not explicitly part of the link.

This patches it back to a blank string, which matches modern behavior.

Fixes #472