### PR TITLE
ie11 sameOrigin detection fix

### DIFF
--- a/page.js
+++ b/page.js
@@ -406,7 +406,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * Module dependencies.
    */
 
-  
+
 
   /**
    * Short-cuts for global-object checks
@@ -893,6 +893,12 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     var window = this._window;
 
     var loc = window.location;
+
+    /*
+       when the port is the default http port 80, internet explorer 11
+       returns an empty string for loc.port, so we need to compare loc.port
+       with an empty string if url.port is the default port 80.
+    */
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
       (loc.port === url.port || loc.port === '' && url.port === 80);

--- a/page.js
+++ b/page.js
@@ -895,7 +895,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     var loc = window.location;
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
-      loc.port === url.port;
+      (loc.port === url.port || loc.port === '' && url.port === 80);
   };
 
   /**


### PR DESCRIPTION
On ie11 loc.port returns an empty string if the port is 80.
This commit fixes the sameOrigin detection function for ie11.