### PR TITLE
Remove Regex "matched text"

### DIFF
--- a/page.js
+++ b/page.js
@@ -1189,6 +1189,8 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       m = this.regexp.exec(decodeURIComponent(pathname));
 
     if (!m) return false;
+	  
+    delete params[0]
 
     for (var i = 1, len = m.length; i < len; ++i) {
       var key = keys[i - 1];

--- a/test/tests.js
+++ b/test/tests.js
@@ -422,6 +422,14 @@
           });
           page('/ctxparams/test/');
         });
+        
+        it('should handle optional first param', function(done) {
+          page(/^\/ctxparams\/(option1|option2)?$/, function(ctx) {
+            expect(ctx.params[0]).to.be.undefined
+            done();
+          });
+          page('/ctxparams/');
+        });
       });
 
       describe('ctx.handled', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -425,7 +425,7 @@
         
         it('should handle optional first param', function(done) {
           page(/^\/ctxparams\/(option1|option2)?$/, function(ctx) {
-            expect(ctx.params[0]).to.be.undefined
+            expect(ctx.params[0]).to.be.undefined;
             done();
           });
           page('/ctxparams/');


### PR DESCRIPTION
In the case that all capture groups from a regex are optional and not supplied in the checked text; context.params[0] will be the "matched text" of the regex. Deleting property 0 from params before populating params prevents this.

https://github.com/visionmedia/page.js/issues/538