### PR TITLE
Listen `hashchange` if popstate = false

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@
       _window.document.removeEventListener(clickEvent, this.clickHandler, false);
     }
 
-    if(this._hashbang && hasWindow && !hasHistory) {
+    if(this._hashbang && hasWindow && !this._popstate) {
       _window.addEventListener('hashchange', this._onpopstate, false);
     } else if(hasWindow) {
       _window.removeEventListener('hashchange', this._onpopstate, false);


### PR DESCRIPTION
Seems we should add an event listener to `hashchange` if `popstate` option equals false and `hashbang` option equals true. In this case, right now back navigation via `history.back()` not working.