### PR TITLE
fix ie11 sameOrigin check on https

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,7 +485,6 @@
    * @param {string} href
    * @api public
    */
-
   Page.prototype.sameOrigin = function(href) {
     if(!href || !isLocation) return false;
 
@@ -493,9 +492,18 @@
     var window = this._window;
 
     var loc = window.location;
+
+    /*
+       When the port is the default http port 80 for http, or 443 for
+       https, internet explorer 11 returns an empty string for loc.port,
+       so we need to compare loc.port with an empty string if url.port
+       is the default port 80 or 443.
+       Also the comparition with `port` is changed from `===` to `==` because
+       `port` can be a string sometimes. This only applies to ie11.
+    */
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
-      loc.port === url.port;
+      (loc.port === url.port || loc.port === '' && (url.port == 80 || url.port == 443)); // jshint ignore:line
   };
 
   /**

--- a/page.js
+++ b/page.js
@@ -406,7 +406,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * Module dependencies.
    */
 
-
+  
 
   /**
    * Short-cuts for global-object checks
@@ -885,7 +885,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * @param {string} href
    * @api public
    */
-
   Page.prototype.sameOrigin = function(href) {
     if(!href || !isLocation) return false;
 
@@ -895,13 +894,14 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     var loc = window.location;
 
     /*
-       when the port is the default http port 80, internet explorer 11
-       returns an empty string for loc.port, so we need to compare loc.port
-       with an empty string if url.port is the default port 80.
+       when the port is the default http port 80 for http, or 443 for
+       https, internet explorer 11 returns an empty string for loc.port,
+       so we need to compare loc.port with an empty string if url.port
+       is the default port 80 or 443.
     */
     return loc.protocol === url.protocol &&
       loc.hostname === url.hostname &&
-      (loc.port === url.port || loc.port === '' && url.port === 80);
+      (loc.port === url.port || loc.port === '' && (url.port == 80 || url.port == 443)); // jshint ignore:line
   };
 
   /**
@@ -1189,8 +1189,6 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       m = this.regexp.exec(decodeURIComponent(pathname));
 
     if (!m) return false;
-	  
-    delete params[0]
 
     for (var i = 1, len = m.length; i < len; ++i) {
       var key = keys[i - 1];


### PR DESCRIPTION
On IE11 if the port is 80 or 443, url.port is empty, so we have to check if port is 443 in case of https too.
Also, `===` got changed to `==`, because url.port is a string on some versions of IE11 (tested on IE11 on Windows 7).

(I really hope I don't have to support this browser for much longer)