### PR TITLE
make the in browsers tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "engine-deps": "install-engine-dependencies",
     "test": "jshint index.js test/tests.js && mocha test/tests.js",
-    "serve": "serve test",
+    "serve": "serve test --symlinks",
     "test-cov": "jscoverage index.js index-cov.js; PAGE_COV=1 mocha test/tests.js -R html-cov > coverage.html",
     "make": "rollup -c rollup.config.js"
   },

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.rawgit.com/visionmedia/mocha/1.20.1/mocha.js"></script>
     <script src="https://cdn.rawgit.com/chaijs/chai/1.9.1/chai.js"></script>
     <script>mocha.setup('bdd')</script>
-    <script src="../page.js"></script>
+    <script src="page.js"></script>
     <script src="tests.js"></script>
     <script>
       mocha.run();


### PR DESCRIPTION
Running `npm run serve` then visiting http://localhost:5000 results in all tests failing.

The problem is that `test/index.html` attempts to reference `../page.js`. This is not allowed by serve.  

However, there is already a symlink from the tests dir to page.js.  So, if we allow serve to follow symlinks then the problem is resolved and all the tests pass.