### PR TITLE
Make query string parameters work when using hashbang routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -728,8 +728,11 @@
   Context.prototype.save = function() {
     var page = this.page;
     if (hasHistory) {
-        page._window.history.replaceState(this.state, this.title,
-          page._hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+      var pathWithoutQuerystring = this.path.replace('?' + this.querystring, '');
+      pathWithoutQuerystring = pathWithoutQuerystring === '' ? '/' : pathWithoutQuerystring;
+
+      page._window.history.replaceState(this.state, this.title,
+        page._hashbang && (pathWithoutQuerystring !== '/' || this.querystring !== '') ? page._window.location.pathname + '#!' + this.path : this.canonicalPath);
     }
   };
 

--- a/page.js
+++ b/page.js
@@ -1128,8 +1128,11 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Context.prototype.save = function() {
     var page = this.page;
     if (hasHistory) {
-        page._window.history.replaceState(this.state, this.title,
-          page._hashbang && this.path !== '/' ? '#!' + this.path : this.canonicalPath);
+      var pathWithoutQuerystring = this.path.replace('?' + this.querystring, '');
+      pathWithoutQuerystring = pathWithoutQuerystring === '' ? '/' : pathWithoutQuerystring;
+
+      page._window.history.replaceState(this.state, this.title,
+        page._hashbang && (pathWithoutQuerystring !== '/' || this.querystring !== '') ? page._window.location.pathname + '#!' + this.path : this.canonicalPath);
     }
   };
 
@@ -1211,11 +1214,11 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    */
 
   var globalPage = createPage();
-  var page_1 = globalPage;
+  var page_js = globalPage;
   var default_1 = globalPage;
 
-page_1.default = default_1;
+page_js.default = default_1;
 
-return page_1;
+return page_js;
 
 })));


### PR DESCRIPTION
When `hashbang` is `true`, urls like http://localhost/?foo=bar got
redirected to http://localhost/?foo=bar#!?foo=bar.
This duplicated the query string and made the url ugly.
This commit fixed this problem by making urls like
http://localhost/?foo=bar redirect to http://localhost/#!?foo=bar

I made some nightwatch tests to make sure all use cases are covered.
The tests can be found here: https://github.com/S2-/page.js-nightwatch-test

All urls work as expected:
```
hashbang: false

navigating to http://127.0.0.1:8001/ -> http://127.0.0.1:8001/
clicking a link href="/hello" -> http://127.0.0.1:8001/hello
clicking a link href="/hello?some=query&str=ing" -> http://127.0.0.1:8001/hello?some=query&str=ing
navigating to http://127.0.0.1:8001/?some=query&str=ing -> http://127.0.0.1:8001/?some=query&str=ing
navigating to http://127.0.0.1:8001/hello?some=query&str=ing -> http://127.0.0.1:8001/hello?some=query&str=ing


hashbang: true

navigating to http://127.0.0.1:8001/ -> http://127.0.0.1:8000/
clicking a link href="/hello" -> http://127.0.0.1:8000/#!/hello'
clicking a link href="/hello?some=query&str=ing" -> http://127.0.0.1:8000/#!/hello?some=query&str=ing'
navigating to http://127.0.0.1:8000/?some=query&str=ing -> http://127.0.0.1:8000/#!?some=query&str=ing'
navigating to http://127.0.0.1:8000/?some=query&str=ing#!/hello -> http://127.0.0.1:8000/#!/hello?some=query&str=ing'
```