### PR TITLE
Fix documentation of named wildcards

### DIFF
--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@ page(<span class="pl-s1"><span class="pl-pds">'</span>*<span class="pl-pds">'</s
 <p>Named wildcard accessed, for example <code>/file/javascripts/jquery.js</code>
   would provide "/javascripts/jquery.js" as <code>ctx.params.file</code>:</p>
 
-<div class="highlight highlight-js"><pre>page(<span class="pl-s1"><span class="pl-pds">'</span>/file/:file(*)<span class="pl-pds">'</span></span>, loadUser)</pre></div>
+<div class="highlight highlight-js"><pre>page(<span class="pl-s1"><span class="pl-pds">'</span>/file/:file(.*)<span class="pl-pds">'</span></span>, loadUser)</pre></div>
 
 <p>And of course <code>RegExp</code> literals, where the capture
   groups are available via <code>ctx.params[N]</code> where <strong>N</strong>


### PR DESCRIPTION
The docs were updated in the README by #506, but the gh-pages site is still incorrect.

Fixes #338

(if there's an auto-generation process for this that should be fixed instead, let me know - I couldn't find it)