### PR TITLE
Fix errors thrown when e.g. an external code calls .pushState without path.

### DIFF
--- a/page.js
+++ b/page.js
@@ -847,7 +847,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     return function onpopstate(e) {
       if (!loaded) return;
       var page = this;
-      if (e.state) {
+      if (e.state && e.state.path) {
         var path = e.state.path;
         page.replace(path, e.state);
       } else if (isLocation) {

--- a/page.mjs
+++ b/page.mjs
@@ -841,7 +841,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
     return function onpopstate(e) {
       if (!loaded) return;
       var page = this;
-      if (e.state) {
+      if (e.state && e.state.path) {
         var path = e.state.path;
         page.replace(path, e.state);
       } else if (isLocation) {


### PR DESCRIPTION
Hi.

I think we should inspect that e.state.path is not null nor undefined
because anyone can call `.pushState` with an arbitrary state argument.
https://developer.mozilla.org/en-US/docs/Web/API/PopStateEvent

I actually encountered this problem when I use an out-of-control external js code which calls `.pushState`.

This should fix #293 .