### PR TITLE
Fix _page typo in Route constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -751,7 +751,7 @@
   function Route(path, options, page) {
     var _page = this.page = page || globalPage;
     var opts = options || {};
-    opts.strict = opts.strict || page._strict;
+    opts.strict = opts.strict || _page._strict;
     this.path = (path === '*') ? '(.*)' : path;
     this.method = 'GET';
     this.regexp = pathtoRegexp(this.path, this.keys = [], opts);

--- a/page.js
+++ b/page.js
@@ -1151,7 +1151,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   function Route(path, options, page) {
     var _page = this.page = page || globalPage;
     var opts = options || {};
-    opts.strict = opts.strict || page._strict;
+    opts.strict = opts.strict || _page._strict;
     this.path = (path === '*') ? '(.*)' : path;
     this.method = 'GET';
     this.regexp = pathToRegexp_1(this.path, this.keys = [], opts);

--- a/page.mjs
+++ b/page.mjs
@@ -1137,7 +1137,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   function Route(path, options, page) {
     var _page = this.page = page || globalPage;
     var opts = options || {};
-    opts.strict = opts.strict || page._strict;
+    opts.strict = opts.strict || _page._strict;
     this.path = (path === '*') ? '(.*)' : path;
     this.method = 'GET';
     this.regexp = pathToRegexp_1(this.path, this.keys = [], opts);

--- a/test/tests.js
+++ b/test/tests.js
@@ -792,4 +792,18 @@
     });
   });
 
+  describe('Route', function() {
+    before(function(done) {
+      beforeTests(null, done);
+    });
+
+    it('Can create Route', function() {
+      var r = new page.Route('/');
+    });
+
+    after(function() {
+      afterTests();
+    });
+  });
+
 }).call(this);


### PR DESCRIPTION
`var _page` can be `page` (passed in as an argument) or `globalPage`. The opts are pulled from the first one instead of either one, this PR corrects that.