### PR TITLE
Original path passed in the callback context

### DIFF
--- a/index.js
+++ b/index.js
@@ -769,7 +769,10 @@
   Route.prototype.middleware = function(fn) {
     var self = this;
     return function(ctx, next) {
-      if (self.match(ctx.path, ctx.params)) return fn(ctx, next);
+      if (self.match(ctx.path, ctx.params)) {
+        ctx.routePath = self.path;
+        return fn(ctx, next);
+      }
       next();
     };
   };

--- a/page.js
+++ b/page.js
@@ -1169,7 +1169,11 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Route.prototype.middleware = function(fn) {
     var self = this;
     return function(ctx, next) {
-      if (self.match(ctx.path, ctx.params)) return fn(ctx, next);
+      
+      if (self.match(ctx.path, ctx.params)) {
+        ctx.routePath = self.path;
+        return fn(ctx, next);
+      }
       next();
     };
   };

--- a/page.mjs
+++ b/page.mjs
@@ -1155,7 +1155,10 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
   Route.prototype.middleware = function(fn) {
     var self = this;
     return function(ctx, next) {
-      if (self.match(ctx.path, ctx.params)) return fn(ctx, next);
+      if (self.match(ctx.path, ctx.params)) {
+        ctx.routePath = self.path;
+        return fn(ctx, next);
+      }
       next();
     };
   };

--- a/test/tests.js
+++ b/test/tests.js
@@ -430,6 +430,14 @@
           });
           page('/ctxparams/');
         });
+
+        it('should have the original routePath', function(done) {
+          page('/route/:param', function(ctx) {
+            expect(ctx.routePath).to.equal('/route/:param');
+            done();
+          });
+          page('/route/value');
+        });
       });
 
       describe('ctx.handled', function() {


### PR DESCRIPTION
`routePath` param added which contains the original string path provided in the page function.

```js
page('/profile/:userId', showUser);
page('/profile/5', showUser);

function showUser(ctx) {
  if(ctx.routePath === '/profile/5')
      document.write('Admin User');
  else
    document.write('User No: ', ctx.params.userId);
}
```

Co-Authored-By: Prabakaran Raja <prabakaranrvp@users.noreply.github.com>