### PR TITLE
Fix Context constructor references when a page instance is omitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -666,11 +666,12 @@
    * @constructor
    * @param {string} path
    * @param {Object=} state
+   * @param {Page=} pageInstance
    * @api public
    */
 
   function Context(path, state, pageInstance) {
-    var _page = this.page = pageInstance || page;
+    var _page = this.page = pageInstance || new Page();
     var window = _page._window;
     var hashbang = _page._hashbang;
 

--- a/page.js
+++ b/page.js
@@ -1066,11 +1066,12 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * @constructor
    * @param {string} path
    * @param {Object=} state
+   * @param {Page=} pageInstance
    * @api public
    */
 
   function Context(path, state, pageInstance) {
-    var _page = this.page = pageInstance || page;
+    var _page = this.page = pageInstance || new Page();
     var window = _page._window;
     var hashbang = _page._hashbang;
 

--- a/page.mjs
+++ b/page.mjs
@@ -1060,11 +1060,12 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
    * @constructor
    * @param {string} path
    * @param {Object=} state
+   * @param {Page=} pageInstance
    * @api public
    */
 
   function Context(path, state, pageInstance) {
-    var _page = this.page = pageInstance || page;
+    var _page = this.page = pageInstance || new Page();
     var window = _page._window;
     var hashbang = _page._hashbang;
 


### PR DESCRIPTION
I was attempting to upgrade my version of Page.js, but encountered errors. Unit tests in my project create Context objects directly and those calls were failing. In particular, [_page._getBase()](https://github.com/visionmedia/page.js/blob/4f9991658f9b9e3de9b6059bade93693af24d6bd/index.js#L677) is undefined when the Context object is constructed such as `new page.Context('/some/path')`.

In my project, this isn't used in real code - just tests, but the fallback logic was clearly wrong too.