### PR TITLE
Remove bower from readme since it's deprecated

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,6 @@ page()
   ```bash
   $ npm install page # for browserify
   $ component install visionmedia/page.js
-  $ bower install visionmedia/page.js
   ```
 
   Or use with a CDN. We support:


### PR DESCRIPTION
Bower is deprecated, so we probably shouldn't recommend it for new projects. I have no idea what `component`. It also seems weird to say "for browserify" for `npm`, since most people using `npm` won't use browserify