### PR TITLE
Fix duplicate query string params when hashbang is enabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@
       var loc = window.location;
 
       if(this._hashbang && ~loc.hash.indexOf('#!')) {
-        url = loc.hash.substr(2) + loc.search;
+        url = loc.hash.substr(2) + (~loc.hash.indexOf('?') ? '' : loc.search);
       } else if (this._hashbang) {
         url = loc.search + loc.hash;
       } else {

--- a/page.js
+++ b/page.js
@@ -557,7 +557,7 @@ pathToRegexp_1.tokensToRegExp = tokensToRegExp_1;
       var loc = window.location;
 
       if(this._hashbang && ~loc.hash.indexOf('#!')) {
-        url = loc.hash.substr(2) + loc.search;
+        url = loc.hash.substr(2) + (~loc.hash.indexOf('?') ? '' : loc.search);
       } else if (this._hashbang) {
         url = loc.search + loc.hash;
       } else {

--- a/test/support/jsdom.js
+++ b/test/support/jsdom.js
@@ -8,7 +8,7 @@ function setupJsdom(options, next) {
   function setupGlobals(window) {
     window.console = console;
     if(window.location.protocol !== 'file:')
-      window.history.replaceState(null, '', '/');
+      window.history.replaceState(null, '', '/' + options.qs || '');
     global.window = window;
     global.location = window.location;
     global.document = window.document;

--- a/test/tests.js
+++ b/test/tests.js
@@ -800,6 +800,30 @@
     });
   });
 
+  describei('When hashbang option enabled with base query params', function() {
+    before(function(done){
+      jsdomSupport.setup({
+        qs: '?hello=there'
+      }, done);
+    });
+
+    it('prevents duplicate query params added to hash', function(done) {
+      var count = 0;
+
+      baseRoute = function () {
+        expect(window.location.search).to.equal('?hello=there');
+        expect(window.location.hash).to.equal('#!?hello=there');
+
+        count++;
+        count === 2 && done();
+      };
+
+      page({ hashbang: true });
+      page({ hashbang: true });
+    });
+  });
+
+
   describe('Route', function() {
     before(function(done) {
       beforeTests(null, done);


### PR DESCRIPTION
## Problem
When `hashbang` is enabled, `page.start()` will re-add `location.search` params to the hash. This results in duplicate query params when the page is refreshed.

See #525 and #412 

## Proposed Fix
Add `location.search` params only when a query string has not been added to the hash.

## Notes
It was a challenge to test this. I couldn't figure out how to supply a query string to the `iframe` window. I ended up configuring jsdom with a query string and testing against `window.location`. Please advise if there is a better approach.