### PR TITLE
fix:Omit query and hash part if both apears in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -694,6 +694,7 @@
     this.hash = '';
     if (!hashbang) {
       if (!~this.path.indexOf('#')) return;
+      if (this.path.indexOf('?') > -1) return;
       var parts = this.path.split('#');
       this.path = this.pathname = parts[0];
       this.hash = _page._decodeURLEncodedURIComponent(parts[1]) || '';


### PR DESCRIPTION
Hi 
As mentioned in #575 issue if path have both ?foo=bar and # foo  the page.js only removes # foo part
so i fix this in this commit and now the output is:
canonicalPath /foo?hello=there
pathname /foo
canonicalPath /foo#hash
pathname /foo
canonicalPath /foo?hello=there#hash
pathname /foo

It's my first time contributing to this repo so I'm very happy if anyone has a comment on this.
also i run test and everything works fine